### PR TITLE
first implementation of scripting support (using groovy scripts)

### DIFF
--- a/archetype-common/src/main/java/org/apache/maven/archetype/common/ArchetypeArtifactManager.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/common/ArchetypeArtifactManager.java
@@ -28,6 +28,7 @@ import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.Reader;
 
 import java.util.List;
 import java.util.zip.ZipFile;
@@ -109,5 +110,10 @@ public interface ArchetypeArtifactManager
     org.apache.maven.archetype.old.descriptor.ArchetypeDescriptor getOldArchetypeDescriptor(
             String groupId, String artifactId, String version, ArtifactRepository archetypeRepository,
             ArtifactRepository localRepository, List<ArtifactRepository> repositories )
+        throws UnknownArchetype;
+
+    /**
+     */
+    Reader getScriptFileReader( File archetypeFile, String scriptFile )
         throws UnknownArchetype;
 }

--- a/archetype-common/src/main/java/org/apache/maven/archetype/common/DefaultArchetypeArtifactManager.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/common/DefaultArchetypeArtifactManager.java
@@ -403,6 +403,26 @@ public class DefaultArchetypeArtifactManager
 
         return getOldArchetypeDescriptor( archetypeFile );
     }
+    
+    public Reader getScriptFileReader( File archetypeFile, String scriptFile )
+        throws UnknownArchetype
+    {
+        ZipFile zipFile = null;
+        try
+        {
+            zipFile = getArchetypeZipFile( archetypeFile );
+
+            return getDescriptorReader( zipFile, scriptFile );
+        }
+        catch ( IOException e )
+        {
+            throw new UnknownArchetype( e );
+        }
+        finally
+        {
+            closeZipFile( zipFile );
+        }
+    }
 
     private File getArchetype( String archetypeGroupId, String archetypeArtifactId, String archetypeVersion )
     {
@@ -560,6 +580,11 @@ public class DefaultArchetypeArtifactManager
 
     private ZipEntry searchEntry( ZipFile zipFile, String searchString )
     {
+        if( searchString == null )
+        {
+            return null;
+        }
+    
         getLogger().debug( "Searching for " + searchString + " inside " + zipFile.getName() );
 
         Enumeration<? extends ZipEntry> enu = zipFile.entries();

--- a/archetype-models/archetype-descriptor/src/main/mdo/archetype-descriptor.mdo
+++ b/archetype-models/archetype-descriptor/src/main/mdo/archetype-descriptor.mdo
@@ -103,6 +103,15 @@
           <description>File sets definition.</description>
         </field>
         <field xdoc.separator="blank">
+          <name>scripts</name>
+          <association>
+            <type>Script</type>
+            <multiplicity>*</multiplicity>
+          </association>
+          <required>false</required>
+          <description>Script definitions.</description>
+        </field>
+        <field xdoc.separator="blank">
           <name>modules</name>
           <association>
             <type>ModuleDescriptor</type>
@@ -197,11 +206,42 @@
           <required>true</required>
           <description>Key value of the property.</description>
         </field>
+        <field xml.attribute="true">
+          <name>assignedByScript</name>
+          <type>boolean</type>
+          <required>false</required>
+          <description>Is this property assigned by scripting.</description>
+        </field>
         <field>
           <name>defaultValue</name>
           <type>String</type>
           <required>false</required>
           <description>Default value of the property.</description>
+        </field>
+      </fields>
+    </class>
+
+    <class>
+      <name>Script</name>
+      <description>Script that should be called to process properties.</description>
+      <fields>
+        <field xml.attribute="true">
+          <name>name</name>
+          <type>String</type>
+          <required>true</required>
+          <description>Name of the script (allowed characters A-Z, a-z, 0-9).</description>
+        </field>
+        <field xml.attribute="true">
+          <name>file</name>
+          <type>String</type>
+          <required>true</required>
+          <description>File containing the script.</description>
+        </field>
+        <field xml.attribute="true">
+          <name>language</name>
+          <type>String</type>
+          <required>true</required>
+          <description>Scripting language.</description>
         </field>
       </fields>
     </class>

--- a/archetype-scripting/pom.xml
+++ b/archetype-scripting/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.archetype</groupId>
+    <artifactId>maven-archetype</artifactId>
+    <version>2.0-p1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>archetype-scripting</artifactId>
+  <packaging>jar</packaging>
+  <version>2.0-p1-SNAPSHOT</version>
+
+  <name>Maven Archetype Scripting</name>
+  <description>Scripting extension for Archetype.</description>
+
+  <dependencies>
+	<dependency>
+	  <groupId>org.codehaus.groovy</groupId>
+	  <artifactId>groovy</artifactId>
+      <version>1.7.9</version>
+	</dependency>
+  </dependencies>
+</project>

--- a/archetype-scripting/src/main/java/org/apache/maven/archetype/scripting/ArchetypePropertiesScripter.java
+++ b/archetype-scripting/src/main/java/org/apache/maven/archetype/scripting/ArchetypePropertiesScripter.java
@@ -1,0 +1,30 @@
+package org.apache.maven.archetype.scripting;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+ 
+/**
+ * @author Lucien Weller
+ */
+public interface ArchetypePropertiesScripter {
+
+  String ROLE = ArchetypePropertiesScripter.class.getName();
+
+  public ArchetypePropertyScripterResult executeScript(ArchetypePropertyScripterRequest request);
+}

--- a/archetype-scripting/src/main/java/org/apache/maven/archetype/scripting/ArchetypePropertyScripterRequest.java
+++ b/archetype-scripting/src/main/java/org/apache/maven/archetype/scripting/ArchetypePropertyScripterRequest.java
@@ -1,0 +1,63 @@
+package org.apache.maven.archetype.scripting;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+ 
+import java.io.Reader;
+
+import java.util.Properties;
+ 
+/**
+ * @author Lucien Weller
+ */
+public class ArchetypePropertyScripterRequest {
+  private Properties properties;
+  private String     scriptFileName;
+  private Reader     scriptFileReader;
+  
+  public Properties getProperties() {
+    return properties;
+  }
+
+  public ArchetypePropertyScripterRequest setProperties(Properties properties) {
+    this.properties = properties;
+    
+    return this;
+  }
+
+  public String getScriptFileName() {
+    return scriptFileName;
+  }
+
+  public ArchetypePropertyScripterRequest setScriptFileName(String scriptFileName) {
+    this.scriptFileName = scriptFileName;
+    
+    return this;
+  }
+
+  public Reader getScriptFileReader() {
+    return scriptFileReader;
+  }
+
+  public ArchetypePropertyScripterRequest setScriptFileReader(Reader scriptFileReader) {
+    this.scriptFileReader = scriptFileReader;
+    
+    return this;
+  }
+}

--- a/archetype-scripting/src/main/java/org/apache/maven/archetype/scripting/ArchetypePropertyScripterResult.java
+++ b/archetype-scripting/src/main/java/org/apache/maven/archetype/scripting/ArchetypePropertyScripterResult.java
@@ -1,0 +1,48 @@
+package org.apache.maven.archetype.scripting;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+ 
+import java.util.Properties;
+import java.util.List;
+ 
+/**
+ * @author Lucien Weller
+ */
+public class ArchetypePropertyScripterResult {
+  private Properties  properties;
+  private List<String> errors;
+
+  public ArchetypePropertyScripterResult(Properties properties, List<String> errors) {
+    this.properties = properties;
+    this.errors     = errors;
+  }
+
+  public Properties getProperties() {
+    return properties;
+  }
+
+  public List<String> getErrors() {
+    return errors;
+  }
+
+  public boolean hasErrors() {
+    return !errors.isEmpty();
+  }
+}

--- a/archetype-scripting/src/main/java/org/apache/maven/archetype/scripting/GroovyArchetypePropertiesScripter.java
+++ b/archetype-scripting/src/main/java/org/apache/maven/archetype/scripting/GroovyArchetypePropertiesScripter.java
@@ -1,0 +1,64 @@
+package org.apache.maven.archetype.scripting;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import groovy.lang.Binding;
+import groovy.lang.GroovyShell;
+
+import org.codehaus.groovy.control.CompilationFailedException;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.io.File;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * @author Lucien Weller
+ * @plexus.component
+ */
+public class GroovyArchetypePropertiesScripter implements ArchetypePropertiesScripter {
+  public ArchetypePropertyScripterResult executeScript(ArchetypePropertyScripterRequest request) {
+    Binding binding = new Binding();
+
+    List<String> errors = new ArrayList<String>();
+    binding.setVariable("errors", errors);
+
+    Properties properties = new Properties(request.getProperties());
+    binding.setVariable("properties", properties);
+
+    GroovyShell shell = new GroovyShell(binding);
+
+    try {
+      if(request.getScriptFileName() == null) {
+        shell.evaluate(request.getScriptFileReader());
+      } else {
+        String fileName = new File(request.getScriptFileName()).getName().replaceAll("\\.groovy$", "").replaceAll("[^A-Za-z0-9]", "_");
+        shell.evaluate(request.getScriptFileReader(), fileName);
+      }
+    } catch (CompilationFailedException e) {
+      throw new RuntimeException("Script Error:" + e.getMessage());
+    }
+
+    return new ArchetypePropertyScripterResult(properties, errors);
+  }
+}

--- a/maven-archetype-plugin/pom.xml
+++ b/maven-archetype-plugin/pom.xml
@@ -62,6 +62,10 @@ under the License.
       <artifactId>archetype-common</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.maven.archetype</groupId>
+      <artifactId>archetype-scripting</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
     </dependency>

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/ArchetypeConfiguration.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/ArchetypeConfiguration.java
@@ -19,9 +19,13 @@ package org.apache.maven.archetype.ui;
  * under the License.
  */
 
+import org.apache.maven.archetype.metadata.Script;
+ 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
+import java.util.HashSet;
 
 import org.apache.maven.archetype.common.Constants;
 import org.codehaus.plexus.util.StringUtils;
@@ -63,10 +67,48 @@ public class ArchetypeConfiguration
     private String description;
 
     private List<String> requiredProperties;
+    
+    private Set<String> assignByScriptProperties;
+    
+    private List<Script> scripts;
+    
+    public ArchetypeConfiguration()
+    {
+        assignByScriptProperties = new HashSet<String>();
+        scripts = new ArrayList<Script>();
+    }
 
     public void addRequiredProperty( String string )
     {
-        getRequiredProperties().add( string );
+        addRequiredProperty( string, false );
+    }
+
+    public void addRequiredProperty( String string, boolean assignByScript )
+    {
+        List<String> requiredProperties = getRequiredProperties();
+        if( !requiredProperties.contains( string ) ) 
+        {
+            requiredProperties.add( string );
+            if( assignByScript )
+            {
+                assignByScriptProperties.add( string );
+            }
+        }        
+    }
+    
+    public void addScript( Script script )
+    {
+        scripts.add( script ); 
+    }
+    
+    public boolean isAssignedByScript(String property)
+    {
+        return assignByScriptProperties.contains( property );
+    }
+    
+    public List<Script> getScripts()
+    {
+        return scripts;
     }
 
     public String getArtifactId()
@@ -159,6 +201,11 @@ public class ArchetypeConfiguration
     public Properties getProperties()
     {
         return properties;
+    }
+    
+    public void updateProperties( Properties properties )
+    {
+        this.properties.putAll(properties);
     }
 
     public Properties toProperties()

--- a/maven-archetype-plugin/src/test/java/org/apache/maven/archetype/ui/DefaultArchetypeGenerationConfiguratorTest.java
+++ b/maven-archetype-plugin/src/test/java/org/apache/maven/archetype/ui/DefaultArchetypeGenerationConfiguratorTest.java
@@ -32,6 +32,7 @@ import org.codehaus.plexus.PlexusTestCase;
 import org.codehaus.plexus.components.interactivity.PrompterException;
 import org.easymock.MockControl;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Properties;
 
@@ -47,6 +48,8 @@ public class DefaultArchetypeGenerationConfiguratorTest
         throws Exception
     {
         super.setUp();
+        
+        File archetypeFile = new File("archetype-descriptor.xml");
 
         configurator = (DefaultArchetypeGenerationConfigurator) lookup( ArchetypeGenerationConfigurator.ROLE );
 
@@ -56,12 +59,13 @@ public class DefaultArchetypeGenerationConfiguratorTest
         ArchetypeArtifactManager manager = (ArchetypeArtifactManager) control.getMock();
         manager.exists( "archetypeGroupId", "archetypeArtifactId", "archetypeVersion", null, null, null );
         control.setReturnValue( true );
-        manager.isFileSetArchetype( "archetypeGroupId", "archetypeArtifactId", "archetypeVersion", null, null, null );
+        manager.getArchetypeFile( "archetypeGroupId", "archetypeArtifactId", "archetypeVersion", null, null, null);
+        control.setReturnValue( archetypeFile );
+        manager.isFileSetArchetype( archetypeFile );
         control.setReturnValue( false );
-        manager.isOldArchetype( "archetypeGroupId", "archetypeArtifactId", "archetypeVersion", null, null, null );
+        manager.isOldArchetype( archetypeFile );
         control.setReturnValue( true );
-        manager.getOldArchetypeDescriptor( "archetypeGroupId", "archetypeArtifactId", "archetypeVersion", null,
-                                               null, null );
+        manager.getOldArchetypeDescriptor( archetypeFile );
         control.setReturnValue( new ArchetypeDescriptor() );
         control.replay();
         configurator.setArchetypeArtifactManager( manager );

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@ under the License.
     <module>archetype-testing</module>
     <module>archetype-models</module>
     <module>archetype-common</module>
+    <module>archetype-scripting</module>
     <module>maven-archetype-plugin</module>
     <module>archetype-packaging</module>
   </modules>
@@ -93,6 +94,11 @@ under the License.
       <dependency>
         <groupId>org.apache.maven.archetype</groupId>
         <artifactId>archetype-common</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven.archetype</groupId>
+        <artifactId>archetype-scripting</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
This pull request is intended to show a possible extension for maven-archetype. I would be happy to become at least some feed back about utility of such a feature and chances to see this (or something similar) in maven-archetype in future.

I extended maven-achretype to allow some scripting while generating a new project from an archetype. I did'nt used the approch of an other templating engine (as suggested by issue ARCHETYPE-155), but simply added a scripting step after properties where configures. This allows to manipulate existing properties, create new ones or simply validate them.

Concretely I extended the archetype-metadata.xml descriptor like this:

First of all definition of scripts to execute after properties and before generation will start:
  <scripts>
    <script name="ComputePackage" file="scripts/compute-package.groovy" language="groovy" />
  </scripts>

Attribute on existing requiredProperty element to specify that a property will be computed by scripting:
  <requiredProperty key="package" assignedByScript="true" />
  <requiredProperty key="packageDir" assignedByScript="true" />

Script itself is a groovy script (may be extended to other languges) that has two read/write implicit variables:
- properties : containing required properties after configuration step
- errors : a list of strings representing several error messages (will prevent generation if not emtpy at end)

Benefits:
- fully compliant with actual archetypes
- benefit of powerful scripting language to compute/enforce some configurations

Feedback welcome. Hope this may help you to improve maven-archetype in future.
