### PR TITLE
grammar fix in exception message

### DIFF
--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/JarMojo.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/JarMojo.java
@@ -120,7 +120,7 @@ public class JarMojo
             }
             else
             {
-                throw new MojoExecutionException( "The current project does not built an archetype" );
+                throw new MojoExecutionException( "The current project does not build an archetype" );
             }
         }
         catch ( UnknownArchetype ua )


### PR DESCRIPTION
"The current project does not built an archetype" --> should  be either ""The current project does not build an archetype" or ""The current project has not built an archetype"
