### PR TITLE
Add properties to enable or disable generation of submodules.

### DIFF
--- a/archetype-common/src/main/java/org/apache/maven/archetype/ArchetypeCreationRequest.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/ArchetypeCreationRequest.java
@@ -58,6 +58,8 @@ public class ArchetypeCreationRequest
 
     private File outputDirectory;
 
+    private boolean generateEnableProperties;
+
     public String getPostPhase()
     {
         return postPhase;
@@ -223,6 +225,17 @@ public class ArchetypeCreationRequest
     {
         this.outputDirectory = outputDirectory;
 
+        return this;
+    }
+
+    public boolean isGenerateEnableProperties()
+    {
+        return this.generateEnableProperties;
+    }
+
+    public ArchetypeCreationRequest setGenerateEnableProperies( boolean generateEnableProperties )
+    {
+        this.generateEnableProperties = generateEnableProperties;
         return this;
     }
 }

--- a/archetype-common/src/main/java/org/apache/maven/archetype/common/Constants.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/common/Constants.java
@@ -97,4 +97,6 @@ public interface Constants
     String TMP = ".tmp";
 
     String VERSION = "version";
+
+    String GENERATE_MODULE_PROPERTY_PREFIX = "generate.module.";
 }

--- a/archetype-common/src/main/java/org/apache/maven/archetype/creator/FilesetArchetypeCreator.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/creator/FilesetArchetypeCreator.java
@@ -115,6 +115,7 @@ public class FilesetArchetypeCreator
         boolean partialArchetype = request.isPartialArchetype();
         ArtifactRepository localRepository = request.getLocalRepository();
         File outputDirectory = request.getOutputDirectory();
+        boolean generateEnableProperties = request.isGenerateEnableProperties();
         File basedir = project.getBasedir();
 
         Properties properties = new Properties();
@@ -232,7 +233,7 @@ public class FilesetArchetypeCreator
                     createModule( reverseProperties, rootArtifactId, moduleId, packageName,
                                   FileUtils.resolveFile( basedir, moduleId ),
                                   new File( archetypeFilesDirectory, moduleIdDirectory ), languages, filtereds,
-                                  defaultEncoding, preserveCData, keepParent );
+                                  defaultEncoding, preserveCData, keepParent, generateEnableProperties );
 
                 archetypeDescriptor.addModule( moduleDescriptor );
 
@@ -1002,7 +1003,7 @@ public class FilesetArchetypeCreator
     private ModuleDescriptor createModule( Properties reverseProperties, String rootArtifactId, String moduleId,
                                            String packageName, File basedir, File archetypeFilesDirectory,
                                            List<String> languages, List<String> filtereds, String defaultEncoding,
-                                           boolean preserveCData, boolean keepParent )
+                                           boolean preserveCData, boolean keepParent, boolean generateEnableProperties )
         throws IOException, XmlPullParserException
     {
         ModuleDescriptor archetypeDescriptor = new ModuleDescriptor();
@@ -1029,6 +1030,10 @@ public class FilesetArchetypeCreator
         archetypeDescriptor.setName( replacementId );
         archetypeDescriptor.setId( replacementId );
         archetypeDescriptor.setDir( moduleDirectory );
+        if ( generateEnableProperties )
+        {
+            archetypeDescriptor.setEnableProperty( Constants.GENERATE_MODULE_PROPERTY_PREFIX + moduleId );
+        }
 
         setArtifactId( reverseProperties, pom.getArtifactId() );
 
@@ -1067,7 +1072,7 @@ public class FilesetArchetypeCreator
                 createModule( reverseProperties, rootArtifactId, subModuleId, packageName,
                               FileUtils.resolveFile( basedir, subModuleId ),
                               FileUtils.resolveFile( archetypeFilesDirectory, subModuleIdDirectory ), languages,
-                              filtereds, defaultEncoding, preserveCData, keepParent );
+                              filtereds, defaultEncoding, preserveCData, keepParent, generateEnableProperties );
 
             archetypeDescriptor.addModule( moduleDescriptor );
 

--- a/archetype-common/src/main/java/org/apache/maven/archetype/generator/DefaultFilesetArchetypeGenerator.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/generator/DefaultFilesetArchetypeGenerator.java
@@ -612,20 +612,30 @@ public class DefaultFilesetArchetypeGenerator
         {
             ModuleDescriptor project = subprojects.next();
 
-            File moduleOutputDirectoryFile = new File( outputDirectoryFile,
-                                                       StringUtils.replace( project.getDir(), "__rootArtifactId__",
-                                                                            rootArtifactId ) );
+            String enableProperty = project.getEnableProperty();
+            String enablePropertyValue = (String) context.get( enableProperty );
 
-            context.put( Constants.ARTIFACT_ID,
-                         StringUtils.replace( project.getId(), "${rootArtifactId}", rootArtifactId ) );
+            if ( StringUtils.equals( enablePropertyValue, "false" ) )
+            {
+                getLogger().info( "Skipping disabled module " + project.getId() );
+            }
+            else
+            {
+                File moduleOutputDirectoryFile = new File( outputDirectoryFile,
+                        StringUtils.replace( project.getDir(), "__rootArtifactId__",
+                                rootArtifactId ) );
 
-            processFilesetModule( rootArtifactId,
-                                  StringUtils.replace( project.getDir(), "__rootArtifactId__", rootArtifactId ),
-                                  archetypeResources, new File( moduleOutputDirectoryFile, Constants.ARCHETYPE_POM ),
-                                  archetypeZipFile,
-                                  ( StringUtils.isEmpty( moduleOffset ) ? "" : ( moduleOffset + "/" ) )
-                                      + StringUtils.replace( project.getDir(), "${rootArtifactId}", rootArtifactId ),
-                                  pom, moduleOutputDirectoryFile, packageName, project, context );
+                context.put( Constants.ARTIFACT_ID,
+                        StringUtils.replace( project.getId(), "${rootArtifactId}", rootArtifactId ) );
+
+                processFilesetModule( rootArtifactId,
+                        StringUtils.replace( project.getDir(), "__rootArtifactId__", rootArtifactId ),
+                        archetypeResources, new File( moduleOutputDirectoryFile, Constants.ARCHETYPE_POM ),
+                        archetypeZipFile,
+                        ( StringUtils.isEmpty( moduleOffset ) ? "" : ( moduleOffset + "/" ) )
+                        + StringUtils.replace( project.getDir(), "${rootArtifactId}", rootArtifactId ),
+                        pom, moduleOutputDirectoryFile, packageName, project, context );
+            }
         }
 
         restoreParentArtifactId( context, parentArtifactId );

--- a/archetype-models/archetype-descriptor/src/main/mdo/archetype-descriptor.mdo
+++ b/archetype-models/archetype-descriptor/src/main/mdo/archetype-descriptor.mdo
@@ -87,6 +87,12 @@
           <required>true</required>
           <description>The module's name.</description>
         </field>
+        <field xml.attribute="true">
+          <name>enableProperty</name>
+          <type>String</type>
+          <required>false</required>
+          <description>The name of a property used to enable/disable the generation of the module.</description>
+        </field>
       </fields>
     </class>
 
@@ -159,7 +165,7 @@
             <multiplicity>*</multiplicity>
           </association>
           <required>false</required>
-          <description>Inclusion definition "à la" Ant.</description>
+          <description>Inclusion definition "Ã  la" Ant.</description>
         </field>
         <field>
           <name>excludes</name>
@@ -168,7 +174,7 @@
             <multiplicity>*</multiplicity>
           </association>
           <required>false</required>
-          <description>Exclusion definition "à la" Ant.</description>
+          <description>Exclusion definition "Ã  la" Ant.</description>
         </field>
       </fields>
       <codeSegments>

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/CreateArchetypeFromProjectMojo.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/CreateArchetypeFromProjectMojo.java
@@ -220,6 +220,12 @@ public class CreateArchetypeFromProjectMojo
     @Parameter( property = "packageName" )
     private String packageName; //Find a better way to resolve the package!!! enforce usage of the configurator
 
+    /**
+     * Create properties that would be used to enable/disable the generation of specific modules.
+     */
+    @Parameter( property = "generateEnableProperties" )
+    private boolean generateEnableProperties;
+
     @Parameter( defaultValue = "${session}", readonly = true, required = true )
     private MavenSession session;
 
@@ -251,7 +257,7 @@ public class CreateArchetypeFromProjectMojo
                 /* This should be used before there and use only languages and filtereds */.setArchetypeRegistryFile(
                     archetypeRegistryFile ).setLocalRepository( localRepository )
                 /* this should be resolved and asked for user to verify */.setPackageName( packageName ).setPostPhase(
-                    archetypePostPhase ).setOutputDirectory( outputDirectory );
+                    archetypePostPhase ).setOutputDirectory( outputDirectory ).setGenerateEnableProperies( generateEnableProperties );
 
             ArchetypeCreationResult result = manager.createArchetypeFromProject( request );
 

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/DefaultArchetypeFactory.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/DefaultArchetypeFactory.java
@@ -26,6 +26,7 @@ import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.logging.AbstractLogEnabled;
 
+import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.Properties;
 
@@ -255,6 +256,16 @@ public class DefaultArchetypeFactory
         configuration.setUrl( properties.getProperty( Constants.ARCHETYPE_URL ) );
 
         configuration.setDescription( properties.getProperty( Constants.ARCHETYPE_DESCRIPTION ) );
+
+        Enumeration<?> propertyNames = properties.propertyNames();
+        while ( propertyNames.hasMoreElements() )
+        {
+            String key = (String) propertyNames.nextElement();
+            if ( key.startsWith( Constants.GENERATE_MODULE_PROPERTY_PREFIX ) )
+            {
+                configuration.setProperty ( key, properties.getProperty( key ) );
+            }
+        }
 
         return configuration;
     }


### PR DESCRIPTION
By setting -DgenerateEnableProperties=true when calling the create-from-project goal, the plugin would create enabler properties for each child module in the form generate.module.X. When calling the generate goal thereafter, one can exclude a module by passing -Dgenerate.module.X=false.

See http://stackoverflow.com/questions/34735040/can-a-multi-module-maven-archetype-be-set-up-to-have-optional-modules for the context.

Also see https://issues.apache.org/jira/browse/ARCHETYPE-274.
