### PR TITLE
Archetype 562

### DIFF
--- a/archetype-common/pom.xml
+++ b/archetype-common/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.maven.archetype</groupId>
     <artifactId>maven-archetype</artifactId>
-    <version>3.0.2-TECHEDGE</version>
+    <version>3.0.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>archetype-common</artifactId>

--- a/archetype-common/pom.xml
+++ b/archetype-common/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.maven.archetype</groupId>
     <artifactId>maven-archetype</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.0.2-TECHEDGE</version>
   </parent>
 
   <artifactId>archetype-common</artifactId>

--- a/archetype-models/archetype-catalog/pom.xml
+++ b/archetype-models/archetype-catalog/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.maven.archetype</groupId>
     <artifactId>archetype-models</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.0.2-TECHEDGE</version>
   </parent>
 
   <artifactId>archetype-catalog</artifactId>

--- a/archetype-models/archetype-catalog/pom.xml
+++ b/archetype-models/archetype-catalog/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.maven.archetype</groupId>
     <artifactId>archetype-models</artifactId>
-    <version>3.0.2-TECHEDGE</version>
+    <version>3.0.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>archetype-catalog</artifactId>

--- a/archetype-models/archetype-descriptor/pom.xml
+++ b/archetype-models/archetype-descriptor/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.maven.archetype</groupId>
     <artifactId>archetype-models</artifactId>
-    <version>3.0.2-TECHEDGE</version>
+    <version>3.0.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>archetype-descriptor</artifactId>

--- a/archetype-models/archetype-descriptor/pom.xml
+++ b/archetype-models/archetype-descriptor/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.maven.archetype</groupId>
     <artifactId>archetype-models</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.0.2-TECHEDGE</version>
   </parent>
 
   <artifactId>archetype-descriptor</artifactId>

--- a/archetype-models/pom.xml
+++ b/archetype-models/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.maven.archetype</groupId>
     <artifactId>maven-archetype</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.0.2-TECHEDGE</version>
   </parent>
 
   <artifactId>archetype-models</artifactId>

--- a/archetype-models/pom.xml
+++ b/archetype-models/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.apache.maven.archetype</groupId>
     <artifactId>maven-archetype</artifactId>
-    <version>3.0.2-TECHEDGE</version>
+    <version>3.0.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>archetype-models</artifactId>

--- a/archetype-packaging/pom.xml
+++ b/archetype-packaging/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.maven.archetype</groupId>
     <artifactId>maven-archetype</artifactId>
-    <version>3.0.2-TECHEDGE</version>
+    <version>3.0.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>archetype-packaging</artifactId>

--- a/archetype-packaging/pom.xml
+++ b/archetype-packaging/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <groupId>org.apache.maven.archetype</groupId>
     <artifactId>maven-archetype</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.0.2-TECHEDGE</version>
   </parent>
 
   <artifactId>archetype-packaging</artifactId>

--- a/archetype-testing/archetype-final/pom.xml
+++ b/archetype-testing/archetype-final/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>archetype-testing</artifactId>
     <groupId>org.apache.maven.archetype</groupId>
-    <version>3.0.2-TECHEDGE</version>
+    <version>3.0.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>archetype-final</artifactId>

--- a/archetype-testing/archetype-final/pom.xml
+++ b/archetype-testing/archetype-final/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>archetype-testing</artifactId>
     <groupId>org.apache.maven.archetype</groupId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.0.2-TECHEDGE</version>
   </parent>
 
   <artifactId>archetype-final</artifactId>

--- a/archetype-testing/archetype-proxy/pom.xml
+++ b/archetype-testing/archetype-proxy/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>archetype-testing</artifactId>
     <groupId>org.apache.maven.archetype</groupId>
-    <version>3.0.2-TECHEDGE</version>
+    <version>3.0.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>archetype-proxy</artifactId>

--- a/archetype-testing/archetype-proxy/pom.xml
+++ b/archetype-testing/archetype-proxy/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>archetype-testing</artifactId>
     <groupId>org.apache.maven.archetype</groupId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.0.2-TECHEDGE</version>
   </parent>
 
   <artifactId>archetype-proxy</artifactId>

--- a/archetype-testing/archetype-repository/pom.xml
+++ b/archetype-testing/archetype-repository/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>archetype-testing</artifactId>
     <groupId>org.apache.maven.archetype</groupId>
-    <version>3.0.2-TECHEDGE</version>
+    <version>3.0.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>archetype-repository</artifactId>

--- a/archetype-testing/archetype-repository/pom.xml
+++ b/archetype-testing/archetype-repository/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>archetype-testing</artifactId>
     <groupId>org.apache.maven.archetype</groupId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.0.2-TECHEDGE</version>
   </parent>
 
   <artifactId>archetype-repository</artifactId>

--- a/archetype-testing/pom.xml
+++ b/archetype-testing/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>maven-archetype</artifactId>
     <groupId>org.apache.maven.archetype</groupId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.0.2-TECHEDGE</version>
   </parent>
 
   <artifactId>archetype-testing</artifactId>

--- a/archetype-testing/pom.xml
+++ b/archetype-testing/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <artifactId>maven-archetype</artifactId>
     <groupId>org.apache.maven.archetype</groupId>
-    <version>3.0.2-TECHEDGE</version>
+    <version>3.0.3-SNAPSHOT</version>
   </parent>
 
   <artifactId>archetype-testing</artifactId>

--- a/maven-archetype-plugin/pom.xml
+++ b/maven-archetype-plugin/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.maven.archetype</groupId>
     <artifactId>maven-archetype</artifactId>
-    <version>3.0.2-SNAPSHOT</version>
+    <version>3.0.2-TECHEDGE</version>
   </parent>
 
   <!--

--- a/maven-archetype-plugin/pom.xml
+++ b/maven-archetype-plugin/pom.xml
@@ -26,7 +26,7 @@
   <parent>
     <groupId>org.apache.maven.archetype</groupId>
     <artifactId>maven-archetype</artifactId>
-    <version>3.0.2-TECHEDGE</version>
+    <version>3.0.3-SNAPSHOT</version>
   </parent>
 
   <!--

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeGenerationConfigurator.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeGenerationConfigurator.java
@@ -172,13 +172,14 @@ public class DefaultArchetypeGenerationConfigurator
             {
                 List<String> propertiesRequired = archetypeConfiguration.getRequiredProperties();
                 List<String> unorderedrequiredList;
-                do{
-                    unorderedrequiredList = (List<String>) ((ArrayList) propertiesRequired).clone();
+                do
+                {
+                    unorderedrequiredList = ( List<String> ) ( ( ArrayList ) propertiesRequired ).clone();
                     getLogger().debug( "Required properties before content sort: " + unorderedrequiredList );
                     Collections.sort( propertiesRequired, new RequiredPropertyComparator( archetypeConfiguration ) ); 
                     getLogger().debug( "Required properties after content sort: " + propertiesRequired );
                 }
-                while(!unorderedrequiredList.equals(propertiesRequired));
+                while ( !unorderedrequiredList.equals( propertiesRequired ) );
                     
                 if ( !archetypeConfiguration.isConfigured() )
                 {
@@ -331,17 +332,18 @@ public class DefaultArchetypeGenerationConfigurator
         for ( String property : archetypeConfiguration.getRequiredProperties() )
         {
             Pattern p = Pattern.compile( "\\$\\{" + property + "(\\..*?)?\\}" );
-            Matcher m = p.matcher(result);
-            if (m.find()) 
+            Matcher m = p.matcher( result );
+            if ( m.find() ) 
             {
                 String transitiveProperty = archetypeConfiguration.getProperty( property );
                 String methods = m.group( 1 );
-               if( !StringUtils.isEmpty( methods ) ){
+               if ( !StringUtils.isEmpty( methods ) )
+               {
                    result = m.replaceAll( "\\${\"" + transitiveProperty +  "\"" + methods + "}" );
                }
                else 
                {
-                   result = m.replaceAll(transitiveProperty);
+                   result = m.replaceAll( transitiveProperty );
                }
             }
         }

--- a/maven-archetype-plugin/src/test/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeGenerationConfigurator3Test.java
+++ b/maven-archetype-plugin/src/test/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeGenerationConfigurator3Test.java
@@ -1,0 +1,174 @@
+package org.apache.maven.archetype.ui.generation;
+
+import java.io.ByteArrayInputStream;
+import java.lang.reflect.Field;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.util.Properties;
+
+import org.apache.maven.archetype.ArchetypeGenerationRequest;
+import org.apache.maven.archetype.common.ArchetypeArtifactManager;
+import org.apache.maven.archetype.metadata.ArchetypeDescriptor;
+import org.apache.maven.archetype.metadata.RequiredProperty;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.codehaus.plexus.PlexusTestCase;
+import org.codehaus.plexus.components.interactivity.DefaultInputHandler;
+import org.codehaus.plexus.components.interactivity.DefaultPrompter;
+import org.codehaus.plexus.components.interactivity.InputHandler;
+import org.codehaus.plexus.components.interactivity.Prompter;
+import org.easymock.MockControl;
+import org.junit.Ignore;
+import org.junit.Test;
+
+/**
+ * Tests the ability to use variables in default fields in batch mode
+ */
+public class DefaultArchetypeGenerationConfigurator3Test
+    extends PlexusTestCase
+{
+    private DefaultArchetypeGenerationConfigurator configurator;
+    private ArchetypeGenerationQueryer archetypeGenerationQueryer;
+    private Prompter keyboardMock;
+    private MockControl keyboardControl;
+
+    public void setUp()
+        throws Exception
+    {
+        super.setUp();
+
+        configurator = (DefaultArchetypeGenerationConfigurator) lookup( ArchetypeGenerationConfigurator.ROLE );
+        archetypeGenerationQueryer = (DefaultArchetypeGenerationQueryer) lookup ( ArchetypeGenerationQueryer.class );
+
+        ProjectBuildingRequest buildingRequest = null;
+        
+        MockControl control = MockControl.createControl( ArchetypeArtifactManager.class );
+        control.setDefaultMatcher( MockControl.ALWAYS_MATCHER );
+
+        ArchetypeArtifactManager manager = (ArchetypeArtifactManager) control.getMock();
+        manager.exists( "archetypeGroupId", "archetypeArtifactId", "archetypeVersion", null, null, null, buildingRequest );
+        control.setReturnValue( true );
+        manager.isFileSetArchetype( "archetypeGroupId", "archetypeArtifactId", "archetypeVersion", null, null, null, buildingRequest );
+        control.setReturnValue( true );
+        manager.isOldArchetype( "archetypeGroupId", "archetypeArtifactId", "archetypeVersion", null, null, null, buildingRequest );
+        control.setReturnValue( false );
+        manager.getFileSetArchetypeDescriptor( "archetypeGroupId", "archetypeArtifactId", "archetypeVersion", null,
+                                               null, null, buildingRequest );
+        ArchetypeDescriptor descriptor = new ArchetypeDescriptor();
+        RequiredProperty groupId = new RequiredProperty();
+        groupId.setKey( "groupId" );
+        groupId.setDefaultValue( "com.example.${projectName}" );
+        RequiredProperty artifactId = new RequiredProperty();
+        artifactId.setKey( "artifactId" );
+        artifactId.setDefaultValue( "${projectName}-${domainName}" );
+        RequiredProperty thePackage = new RequiredProperty();
+        thePackage.setKey( "package" );
+        thePackage.setDefaultValue( "com.example.${projectName}.${domainName}" );
+        RequiredProperty projectName = new RequiredProperty();
+        projectName.setKey( "projectName" );
+        projectName.setDefaultValue( null );
+        RequiredProperty domainName = new RequiredProperty();
+        domainName.setKey( "domainName" );
+        domainName.setDefaultValue( null );
+        RequiredProperty snakeCaseProperty = new RequiredProperty();
+        snakeCaseProperty.setKey( "snakeCaseProperty" );
+        snakeCaseProperty.setDefaultValue( "${projectName.toUpperCase()}_${domainName.toUpperCase()}" );
+        descriptor.addRequiredProperty( projectName );
+        descriptor.addRequiredProperty( groupId );
+        descriptor.addRequiredProperty( domainName );
+        descriptor.addRequiredProperty( artifactId );
+        descriptor.addRequiredProperty( thePackage );
+        descriptor.addRequiredProperty(snakeCaseProperty);
+        control.setReturnValue( descriptor );
+        control.replay();
+        configurator.setArchetypeArtifactManager( manager );   
+        
+        keyboardControl = MockControl.createControl( Prompter.class );   
+        keyboardControl.setDefaultMatcher( MockControl.EQUALS_MATCHER );
+        keyboardMock = (Prompter) keyboardControl.getMock();
+        
+        Field archetypeGenerationQueryerField = DefaultArchetypeGenerationConfigurator.class.getDeclaredField("archetypeGenerationQueryer");
+        archetypeGenerationQueryerField.setAccessible(true);
+        archetypeGenerationQueryerField.set(configurator, archetypeGenerationQueryer);
+        
+        Field prompterField = DefaultArchetypeGenerationQueryer.class.getDeclaredField("prompter");
+        prompterField.setAccessible(true);
+      //  prompterField.set(archetypeGenerationQueryer, keyboardMock);
+        
+    }
+
+    public void testJIRA_562_PropertiesReferringEachOtherIndirectly() throws Exception
+    {
+                
+        // Record Keyboard Inputs
+        keyboardMock.prompt("Define value for property 'projectName'"); // projectName property without default value
+        keyboardControl.setReturnValue("myprojectname");
+        
+        keyboardMock.prompt("Define value for property 'groupId'", "com.example.myprojectname"); // groupId property (confirm default proposed value)
+        keyboardControl.setReturnValue("com.example.myprojectname");
+        
+        keyboardMock.prompt("Define value for property 'domainName'"); // domainName property without default value
+        keyboardControl.setReturnValue("mydomainname");
+        
+        keyboardMock.prompt("Define value for property 'artifactId'", "myprojectname-mydomainname"); // artifactId property (confirm default proposed value)
+        keyboardControl.setReturnValue("myprojectname-mydomainname");
+        
+        keyboardMock.prompt("Define value for property 'version'", "1.0-SNAPSHOT"); // version property (confirm default proposed value)
+        keyboardControl.setReturnValue("1.0-SNAPSHOT");
+        
+        keyboardMock.prompt("Define value for property 'package'", "com.example.myprojectname.mydomainname"); // package property (confirm default proposed value)
+        keyboardControl.setReturnValue("com.example.myprojectname.mydomainname");
+        
+        keyboardMock.prompt("Define value for property 'snakeCaseProperty'", "MYPROJECTNAME_MYDOMAINNAME");  // snake case property (confirm default proposed value)
+        keyboardControl.setReturnValue("MYPROJECTNAME_MYDOMAINNAME");
+        
+        keyboardMock.prompt("Confirm properties configuration:\n"
+                + "projectName: myprojectname\n"
+                + "groupId: com.example.myprojectname\n"
+                + "domainName: mydomainname\n"
+                + "artifactId: myprojectname-mydomainname\n"
+                + "version: 1.0-SNAPSHOT\n"
+                + "package: com.example.myprojectname.mydomainname\n"
+                + "snakeCaseProperty: MYPROJECTNAME_MYDOMAINNAME\n", "Y");  // Accept config (Default Y)
+        keyboardControl.setReturnValue("Y");
+        keyboardControl.replay();
+        
+        // Reproduce maven archetype generation (interactive mode)
+        ArchetypeGenerationRequest request = new ArchetypeGenerationRequest();
+        request.setArchetypeGroupId( "archetypeGroupId" );
+        request.setArchetypeArtifactId( "archetypeArtifactId" );
+        request.setArchetypeVersion( "archetypeVersion" );
+        Properties properties = new Properties();
+                
+        // Simulate interactive mode to force param ordering
+        configurator.configureArchetype( request, Boolean.TRUE, properties );
+                
+        keyboardControl.verify();
+        
+        assertEquals( "com.example.myprojectname", request.getGroupId() );
+        assertEquals( "myprojectname-mydomainname", request.getArtifactId() );
+        assertEquals( "1.0-SNAPSHOT", request.getVersion() );
+        assertEquals( "com.example.myprojectname.mydomainname", request.getPackage() );
+        assertEquals( "MYPROJECTNAME_MYDOMAINNAME", request.getProperties().get( "snakeCaseProperty" ) );
+        
+        
+    }
+          
+}

--- a/maven-archetype-plugin/src/test/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeGenerationConfigurator3Test.java
+++ b/maven-archetype-plugin/src/test/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeGenerationConfigurator3Test.java
@@ -90,12 +90,13 @@ public class DefaultArchetypeGenerationConfigurator3Test
         RequiredProperty snakeCaseProperty = new RequiredProperty();
         snakeCaseProperty.setKey( "snakeCaseProperty" );
         snakeCaseProperty.setDefaultValue( "${projectName.toUpperCase()}_${domainName.toUpperCase()}" );
-        descriptor.addRequiredProperty( projectName );
-        descriptor.addRequiredProperty( groupId );
-        descriptor.addRequiredProperty( domainName );
-        descriptor.addRequiredProperty( artifactId );
-        descriptor.addRequiredProperty( thePackage );
         descriptor.addRequiredProperty(snakeCaseProperty);
+        descriptor.addRequiredProperty( thePackage );
+        descriptor.addRequiredProperty( projectName );
+        descriptor.addRequiredProperty( domainName );
+        descriptor.addRequiredProperty( groupId );
+        descriptor.addRequiredProperty( artifactId );
+        
         control.setReturnValue( descriptor );
         control.replay();
         configurator.setArchetypeArtifactManager( manager );   
@@ -110,7 +111,7 @@ public class DefaultArchetypeGenerationConfigurator3Test
         
         Field prompterField = DefaultArchetypeGenerationQueryer.class.getDeclaredField("prompter");
         prompterField.setAccessible(true);
-      //  prompterField.set(archetypeGenerationQueryer, keyboardMock);
+        prompterField.set(archetypeGenerationQueryer, keyboardMock);
         
     }
 
@@ -142,9 +143,9 @@ public class DefaultArchetypeGenerationConfigurator3Test
         keyboardMock.prompt("Confirm properties configuration:\n"
                 + "projectName: myprojectname\n"
                 + "groupId: com.example.myprojectname\n"
+                + "version: 1.0-SNAPSHOT\n"
                 + "domainName: mydomainname\n"
                 + "artifactId: myprojectname-mydomainname\n"
-                + "version: 1.0-SNAPSHOT\n"
                 + "package: com.example.myprojectname.mydomainname\n"
                 + "snakeCaseProperty: MYPROJECTNAME_MYDOMAINNAME\n", "Y");  // Accept config (Default Y)
         keyboardControl.setReturnValue("Y");

--- a/maven-archetype-plugin/src/test/java/org/apache/maven/archetype/ui/generation/RequiredPropertyComparatorTest.java
+++ b/maven-archetype-plugin/src/test/java/org/apache/maven/archetype/ui/generation/RequiredPropertyComparatorTest.java
@@ -67,4 +67,16 @@ public class RequiredPropertyComparatorTest
         Collections.sort( requiredProperties, requiredPropertyComparator );
         assertEquals( Arrays.asList( "prop2", "prop1" ), requiredProperties );
     }
+    
+    public void testShouldOrderPropertiesWhenReferringEachOther3()
+    {
+        archetypeConfiguration.addRequiredProperty( "prop1" );
+        archetypeConfiguration.setDefaultProperty( "prop1", "${prop2.toLowerCase().toString()}" );
+        archetypeConfiguration.addRequiredProperty( "prop2" );
+
+        List<String> requiredProperties = archetypeConfiguration.getRequiredProperties();
+        assertEquals( Arrays.asList( "prop1", "prop2" ), requiredProperties );
+        Collections.sort( requiredProperties, requiredPropertyComparator );
+        assertEquals( Arrays.asList( "prop2", "prop1" ), requiredProperties );
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,357 +1,350 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements. See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership. The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License. You may obtain a copy of the License at
+<!-- Licensed to the Apache Software Foundation (ASF) under one or more contributor 
+	license agreements. See the NOTICE file distributed with this work for additional 
+	information regarding copyright ownership. The ASF licenses this file to 
+	you under the Apache License, Version 2.0 (the "License"); you may not use 
+	this file except in compliance with the License. You may obtain a copy of 
+	the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required 
+	by applicable law or agreed to in writing, software distributed under the 
+	License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS 
+	OF ANY KIND, either express or implied. See the License for the specific 
+	language governing permissions and limitations under the License. -->
 
-  http://www.apache.org/licenses/LICENSE-2.0
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied. See the License for the
-  specific language governing permissions and limitations
-  under the License.
--->
+	<parent>
+		<groupId>org.apache.maven</groupId>
+		<artifactId>maven-parent</artifactId>
+		<version>30</version>
+	</parent>
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+	<groupId>org.apache.maven.archetype</groupId>
+	<artifactId>maven-archetype</artifactId>
+	<version>3.0.2-SNAPSHOT</version>
+	<packaging>pom</packaging>
 
-  <parent>
-    <groupId>org.apache.maven</groupId>
-    <artifactId>maven-parent</artifactId>
-    <version>30</version>
-  </parent>
-
-  <groupId>org.apache.maven.archetype</groupId>
-  <artifactId>maven-archetype</artifactId>
-  <version>3.0.2-SNAPSHOT</version>
-  <packaging>pom</packaging>
-
-  <name>Maven Archetype</name>
-  <description>Maven Archetype is a set of tools to deal with archetypes, i.e. an abstract representation of a kind of project
+	<name>Maven Archetype</name>
+	<description>Maven Archetype is a set of tools to deal with archetypes, i.e. an abstract representation of a kind of project
    that can be instantiated into a concrete customized Maven project.
    An archetype knows which files will be part of the instantiated project and which properties to fill to properly customize
    the project.
   </description>
-  <url>http://maven.apache.org/archetype</url>
-  <inceptionYear>2007</inceptionYear>
+	<url>http://maven.apache.org/archetype</url>
+	<inceptionYear>2007</inceptionYear>
 
-  <modules>
-    <module>archetype-testing</module>
-    <module>archetype-models</module>
-    <module>archetype-common</module>
-    <module>maven-archetype-plugin</module>
-    <module>archetype-packaging</module>
-  </modules>
+	<modules>
+		<module>archetype-testing</module>
+		<module>archetype-models</module>
+		<module>archetype-common</module>
+		<module>maven-archetype-plugin</module>
+		<module>archetype-packaging</module>
+	</modules>
 
-  <scm>
-    <connection>${maven.archetype.scm.devConnection}</connection>
-    <developerConnection>${maven.archetype.scm.devConnection}</developerConnection>
-    <url>https://git-wip-us.apache.org/repos/asf?p=maven-archetype.git;a=summary</url>
-    <tag>HEAD</tag>
-  </scm>
-  <issueManagement>
-    <system>jira</system>
-    <url>https://issues.apache.org/jira/browse/ARCHETYPE</url>
-  </issueManagement>
-  <ciManagement>
-    <system>Jenkins</system>
-    <url>https://builds.apache.org/job/maven-archetype-m3/</url>
-  </ciManagement>
+	<scm>
+		<developerConnection>scm:git:https://github.com/dcasagu/maven-archetype.git</developerConnection>
+		<tag>V${project.version}</tag>
+	</scm>
 
-  <distributionManagement>
-    <site>
-      <id>apache.website</id>
-      <url>scm:svn:https://svn.apache.org/repos/infra/websites/production/maven/components/${maven.site.path}</url>
-    </site>
-  </distributionManagement>
+	<issueManagement>
+		<system>jira</system>
+		<url>https://issues.apache.org/jira/browse/ARCHETYPE</url>
+	</issueManagement>
+	<ciManagement>
+		<system>Jenkins</system>
+		<url>https://builds.apache.org/job/maven-archetype-m3/</url>
+	</ciManagement>
 
-  <properties>
-    <maven.archetype.scm.devConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven-archetype.git</maven.archetype.scm.devConnection>
-    <mavenVersion>3.0</mavenVersion>
-    <netbeans.hint.useExternalMaven>true</netbeans.hint.useExternalMaven>
-    <wagonVersion>2.8</wagonVersion>
-    <maven.site.path>archetype-archives/archetype-LATEST</maven.site.path>
-  </properties>
+	<distributionManagement>
+		<site>
+			<id>apache.website</id>
+			<url>scm:svn:https://svn.apache.org/repos/infra/websites/production/maven/components/${maven.site.path}</url>
+		</site>
+	</distributionManagement>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-compat</artifactId>
-        <version>${mavenVersion}</version>
-        <scope>test</scope>
-      </dependency>
-    
-      <dependency>
-        <groupId>org.apache.maven.archetype</groupId>
-        <artifactId>archetype-catalog</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.archetype</groupId>
-        <artifactId>archetype-descriptor</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.archetype</groupId>
-        <artifactId>archetype-common</artifactId>
-        <version>${project.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.archetype</groupId>
-        <artifactId>archetype-packaging</artifactId>
-        <version>${project.version}</version>
-      </dependency>
+	<properties>
+		<maven.archetype.scm.devConnection>scm:git:https://git-wip-us.apache.org/repos/asf/maven-archetype.git</maven.archetype.scm.devConnection>
+		<mavenVersion>3.0</mavenVersion>
+		<netbeans.hint.useExternalMaven>true</netbeans.hint.useExternalMaven>
+		<wagonVersion>2.8</wagonVersion>
+		<maven.site.path>archetype-archives/archetype-LATEST</maven.site.path>
+	</properties>
 
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-artifact</artifactId>
-        <version>${mavenVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-core</artifactId>
-        <version>${mavenVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-model</artifactId>
-        <version>${mavenVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-plugin-api</artifactId>
-        <version>${mavenVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-settings</artifactId>
-        <version>${mavenVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-settings-builder</artifactId>
-        <version>${mavenVersion}</version>
-      </dependency>
+	<dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-compat</artifactId>
+				<version>${mavenVersion}</version>
+				<scope>test</scope>
+			</dependency>
 
-      <dependency>
-        <groupId>org.apache.maven.shared</groupId>
-        <artifactId>maven-invoker</artifactId>
-        <version>2.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.shared</groupId>
-        <artifactId>maven-artifact-transfer</artifactId>
-        <version>0.9.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-utils</artifactId>
-        <version>3.0.21</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>2.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-interactivity-api</artifactId>
-        <version>1.0-alpha-6</version>
-         <exclusions>
-          <exclusion>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-component-api</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-velocity</artifactId>
-        <version>1.1.8</version>
-        <exclusions>
-          <exclusion>
-            <groupId>velocity</groupId>
-            <artifactId>velocity</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>velocity</groupId>
-            <artifactId>velocity-api</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-container-default</artifactId>
-          </exclusion>
-        </exclusions>
-      </dependency>
-      <dependency>
-        <groupId>dom4j</groupId>
-        <artifactId>dom4j</artifactId>
-        <version>1.6.1</version>
-      </dependency>
-      <dependency>
-        <groupId>jdom</groupId>
-        <artifactId>jdom</artifactId>
-        <version>1.0</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.velocity</groupId>
-        <artifactId>velocity</artifactId>
-        <version>1.7</version>
-      </dependency>
-      <dependency>
-        <groupId>net.sourceforge.jchardet</groupId>
-        <artifactId>jchardet</artifactId>
-        <version>1.0</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-collections</groupId>
-        <artifactId>commons-collections</artifactId>
-        <version>3.2.1</version>
-      </dependency>
-      <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.11</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.plugin-testing</groupId>
-        <artifactId>maven-plugin-testing-harness</artifactId>
-        <version>2.1</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.wagon</groupId>
-        <artifactId>wagon-provider-api</artifactId>
-        <version>${wagonVersion}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.wagon</groupId>
-        <artifactId>wagon-file</artifactId>
-        <version>${wagonVersion}</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.wagon</groupId>
-        <artifactId>wagon-http</artifactId>
-        <version>${wagonVersion}</version>
-        <scope>test</scope>
-      </dependency>
-      
-      <dependency>
-        <groupId>org.sonatype.aether</groupId>
-        <artifactId>aether-connector-file</artifactId>
-        <version>1.7</version>
-      </dependency>
-      <dependency>
-        <groupId>org.sonatype.aether</groupId>
-        <artifactId>aether-connector-wagon</artifactId>
-        <version>1.7</version>
-      </dependency>
-      
-    </dependencies>
-  </dependencyManagement>
+			<dependency>
+				<groupId>org.apache.maven.archetype</groupId>
+				<artifactId>archetype-catalog</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven.archetype</groupId>
+				<artifactId>archetype-descriptor</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven.archetype</groupId>
+				<artifactId>archetype-common</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven.archetype</groupId>
+				<artifactId>archetype-packaging</artifactId>
+				<version>${project.version}</version>
+			</dependency>
 
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-site-plugin</artifactId>
-          <configuration>
-            <topSiteURL>scm:svn:https://svn.apache.org/repos/infra/websites/production/maven/components/${maven.site.path}</topSiteURL>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.codehaus.modello</groupId>
-          <artifactId>modello-maven-plugin</artifactId>
-          <version>1.8.3</version><!-- regression in Modello 1.8 causing build failure -->
-        </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-release-plugin</artifactId>
-          <configuration>
-            <tagBase>https://svn.apache.org/repos/asf/maven/archetype/tags</tagBase>
-            <preparationGoals>clean install</preparationGoals>
-            <autoVersionSubmodules>true</autoVersionSubmodules>
-          </configuration>
-        </plugin>
-        <plugin>
-          <groupId>org.mortbay.jetty</groupId>
-          <artifactId>maven-jetty-plugin</artifactId>
-          <version>6.1.6</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-metadata</artifactId>
-        <executions>
-          <execution>
-            <goals>
-              <goal>generate-metadata</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.rat</groupId>
-        <artifactId>apache-rat-plugin</artifactId>
-        <configuration>
-          <excludes combine.children="append">
-            <exclude>README.txt</exclude>
-            <exclude>*.sh</exclude>
-            <exclude>archetype-samples/**</exclude>
-            <exclude>**/*.sha1</exclude>
-            <!-- exclude template files for generated content -->
-            <exclude>src/main/resources/org/apache/maven/archetype/creator/*</exclude>
-            <!-- exclude some classes coming from dom4j -->
-            <exclude>**/Format.java</exclude>
-            <exclude>**/NamespaceStack.java</exclude>
-            <exclude>**/XMLOutputter.java</exclude>
-            <!-- disable test directories -->
-            <exclude>src/it/**/goal.txt</exclude>
-            <exclude>.repository/**</exclude><!-- for CI -->
-            <!-- Used by JEnv -->
-            <exclude>.java-version</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-enforcer-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>extra-enforcer-rules</artifactId>
-            <version>1.0-beta-6</version>
-          </dependency>
-        </dependencies>
-      </plugin>
-    </plugins>
-  </build>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-artifact</artifactId>
+				<version>${mavenVersion}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-core</artifactId>
+				<version>${mavenVersion}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-model</artifactId>
+				<version>${mavenVersion}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-plugin-api</artifactId>
+				<version>${mavenVersion}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-settings</artifactId>
+				<version>${mavenVersion}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven</groupId>
+				<artifactId>maven-settings-builder</artifactId>
+				<version>${mavenVersion}</version>
+			</dependency>
 
-  <profiles>
-    <profile>
-      <id>reporting</id>
-      <reporting>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-maven-plugin</artifactId>
-            <version>1.3.8</version>
-          </plugin>
-        </plugins>
-      </reporting>
-    </profile>
-  </profiles>
+			<dependency>
+				<groupId>org.apache.maven.shared</groupId>
+				<artifactId>maven-invoker</artifactId>
+				<version>2.2</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven.shared</groupId>
+				<artifactId>maven-artifact-transfer</artifactId>
+				<version>0.9.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.codehaus.plexus</groupId>
+				<artifactId>plexus-utils</artifactId>
+				<version>3.0.21</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-io</groupId>
+				<artifactId>commons-io</artifactId>
+				<version>2.2</version>
+			</dependency>
+			<dependency>
+				<groupId>org.codehaus.plexus</groupId>
+				<artifactId>plexus-interactivity-api</artifactId>
+				<version>1.0-alpha-6</version>
+				<exclusions>
+					<exclusion>
+						<groupId>org.codehaus.plexus</groupId>
+						<artifactId>plexus-component-api</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>org.codehaus.plexus</groupId>
+				<artifactId>plexus-velocity</artifactId>
+				<version>1.1.8</version>
+				<exclusions>
+					<exclusion>
+						<groupId>velocity</groupId>
+						<artifactId>velocity</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>velocity</groupId>
+						<artifactId>velocity-api</artifactId>
+					</exclusion>
+					<exclusion>
+						<groupId>org.codehaus.plexus</groupId>
+						<artifactId>plexus-container-default</artifactId>
+					</exclusion>
+				</exclusions>
+			</dependency>
+			<dependency>
+				<groupId>dom4j</groupId>
+				<artifactId>dom4j</artifactId>
+				<version>1.6.1</version>
+			</dependency>
+			<dependency>
+				<groupId>jdom</groupId>
+				<artifactId>jdom</artifactId>
+				<version>1.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.velocity</groupId>
+				<artifactId>velocity</artifactId>
+				<version>1.7</version>
+			</dependency>
+			<dependency>
+				<groupId>net.sourceforge.jchardet</groupId>
+				<artifactId>jchardet</artifactId>
+				<version>1.0</version>
+			</dependency>
+			<dependency>
+				<groupId>commons-collections</groupId>
+				<artifactId>commons-collections</artifactId>
+				<version>3.2.1</version>
+			</dependency>
+			<dependency>
+				<groupId>junit</groupId>
+				<artifactId>junit</artifactId>
+				<version>4.11</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven.plugin-testing</groupId>
+				<artifactId>maven-plugin-testing-harness</artifactId>
+				<version>2.1</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven.wagon</groupId>
+				<artifactId>wagon-provider-api</artifactId>
+				<version>${wagonVersion}</version>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven.wagon</groupId>
+				<artifactId>wagon-file</artifactId>
+				<version>${wagonVersion}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.apache.maven.wagon</groupId>
+				<artifactId>wagon-http</artifactId>
+				<version>${wagonVersion}</version>
+				<scope>test</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.sonatype.aether</groupId>
+				<artifactId>aether-connector-file</artifactId>
+				<version>1.7</version>
+			</dependency>
+			<dependency>
+				<groupId>org.sonatype.aether</groupId>
+				<artifactId>aether-connector-wagon</artifactId>
+				<version>1.7</version>
+			</dependency>
+
+		</dependencies>
+	</dependencyManagement>
+
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-site-plugin</artifactId>
+					<configuration>
+						<topSiteURL>scm:svn:https://svn.apache.org/repos/infra/websites/production/maven/components/${maven.site.path}</topSiteURL>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.codehaus.modello</groupId>
+					<artifactId>modello-maven-plugin</artifactId>
+					<version>1.8.3</version><!-- regression in Modello 1.8 causing build 
+						failure -->
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-release-plugin</artifactId>
+					<configuration>
+						<tagBase>https://svn.apache.org/repos/asf/maven/archetype/tags</tagBase>
+						<preparationGoals>clean install</preparationGoals>
+						<autoVersionSubmodules>true</autoVersionSubmodules>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.mortbay.jetty</groupId>
+					<artifactId>maven-jetty-plugin</artifactId>
+					<version>6.1.6</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.codehaus.plexus</groupId>
+				<artifactId>plexus-component-metadata</artifactId>
+				<executions>
+					<execution>
+						<goals>
+							<goal>generate-metadata</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.rat</groupId>
+				<artifactId>apache-rat-plugin</artifactId>
+				<configuration>
+					<excludes combine.children="append">
+						<exclude>README.txt</exclude>
+						<exclude>*.sh</exclude>
+						<exclude>archetype-samples/**</exclude>
+						<exclude>**/*.sha1</exclude>
+						<!-- exclude template files for generated content -->
+						<exclude>src/main/resources/org/apache/maven/archetype/creator/*</exclude>
+						<!-- exclude some classes coming from dom4j -->
+						<exclude>**/Format.java</exclude>
+						<exclude>**/NamespaceStack.java</exclude>
+						<exclude>**/XMLOutputter.java</exclude>
+						<!-- disable test directories -->
+						<exclude>src/it/**/goal.txt</exclude>
+						<exclude>.repository/**</exclude><!-- for CI -->
+						<!-- Used by JEnv -->
+						<exclude>.java-version</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<dependencies>
+					<dependency>
+						<groupId>org.codehaus.mojo</groupId>
+						<artifactId>extra-enforcer-rules</artifactId>
+						<version>1.0-beta-6</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<profile>
+			<id>reporting</id>
+			<reporting>
+				<plugins>
+					<plugin>
+						<groupId>org.codehaus.plexus</groupId>
+						<artifactId>plexus-maven-plugin</artifactId>
+						<version>1.3.8</version>
+					</plugin>
+				</plugins>
+			</reporting>
+		</profile>
+	</profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,7 @@
 	OF ANY KIND, either express or implied. See the License for the specific 
 	language governing permissions and limitations under the License. -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -23,7 +22,7 @@
 
 	<groupId>org.apache.maven.archetype</groupId>
 	<artifactId>maven-archetype</artifactId>
-	<version>3.0.2-SNAPSHOT</version>
+	<version>3.0.2-TECHEDGE</version>
 	<packaging>pom</packaging>
 
 	<name>Maven Archetype</name>
@@ -45,7 +44,7 @@
 
 	<scm>
 		<developerConnection>scm:git:https://github.com/dcasagu/maven-archetype.git</developerConnection>
-		<tag>V${project.version}</tag>
+		<tag>v3.0.2-TECHEDGE</tag>
 	</scm>
 
 	<issueManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
 
 	<groupId>org.apache.maven.archetype</groupId>
 	<artifactId>maven-archetype</artifactId>
-	<version>3.0.2-TECHEDGE</version>
+	<version>3.0.3-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Maven Archetype</name>
@@ -44,7 +44,7 @@
 
 	<scm>
 		<developerConnection>scm:git:https://github.com/dcasagu/maven-archetype.git</developerConnection>
-		<tag>v3.0.2-TECHEDGE</tag>
+		<tag>V${project.version}</tag>
 	</scm>
 
 	<issueManagement>


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/ARCHETYPE-562

1)
Collections.sort for ordering assumes transitivity transitivity between just ordered items:
   A < B && B < C => A < C

That's not exactly true for properties that dependends on multiple previous ones.
You must keep ordering until the list does not changes or implement another sort strategy.

2)
Default alphabetical order when there aren't inter-dependencies between properties breaks developer default ordering. We should allow developers to define the preferenced prompt order if it's possible.

3) 
Property transitive values are evaluated only using the exact name reference. Using regexp we provide a way to create transitive dependencies from derived transformations of a property (toLower, toUpper, etc).

 