### PR TITLE
ARCHETYPE-567: switch to dom4j 2.1.1 (and Java 8)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,4 +17,4 @@
  * under the License.
  */
 
-asfMavenTlpPlgnBuild(tmpWs: true)
+asfMavenTlpPlgnBuild(tmpWs: true, jdk:['8','9','10','11','12'])

--- a/archetype-common/pom.xml
+++ b/archetype-common/pom.xml
@@ -78,7 +78,7 @@
       <version>1.5.5</version>
     </dependency>
     <dependency>
-      <groupId>dom4j</groupId>
+      <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
   <properties>
     <maven.archetype.scm.devConnection>scm:git:https://gitbox.apache.org/repos/asf/maven-archetype.git</maven.archetype.scm.devConnection>
     <mavenVersion>3.0</mavenVersion>
-    <javaVersion>7</javaVersion>
+    <javaVersion>8</javaVersion>
     <netbeans.hint.useExternalMaven>true</netbeans.hint.useExternalMaven>
     <wagonVersion>2.8</wagonVersion>
     <surefire.version>2.21.0</surefire.version>
@@ -193,9 +193,9 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>dom4j</groupId>
+        <groupId>org.dom4j</groupId>
         <artifactId>dom4j</artifactId>
-        <version>1.6.1</version>
+        <version>2.1.1</version>
       </dependency>
       <dependency>
         <groupId>jdom</groupId>


### PR DESCRIPTION
dom4j 2.1.1 requires Java 8
dom4j 2.0.2 would retain Java 7 but is vulnerable to CVE-2018-1000632
dom4j 2.0.3 fixes CVE-2018-1000632 but has been pending for ~1 year

Signed-off-by: Tony Homer <tony.homer@intel.com>