### PR TITLE
[ARCHETYPE-548] Filter files with no extension.

### DIFF
--- a/archetype-common/src/main/java/org/apache/maven/archetype/ArchetypeCreationRequest.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/ArchetypeCreationRequest.java
@@ -41,7 +41,9 @@ public class ArchetypeCreationRequest
 
     private List<String> languages = new ArrayList<>();
 
-    private List<String> filtereds = new ArrayList<>();
+    private List<String> filteredFileNames = new ArrayList<>();
+
+    private List<String> filteredFileExtensions = new ArrayList<>();
 
     private String defaultEncoding = "UTF-8";
 
@@ -133,14 +135,26 @@ public class ArchetypeCreationRequest
         return this;
     }
 
-    public List<String> getFiltereds()
+    public List<String> getFilteredFileNames()
     {
-        return filtereds;
+        return filteredFileNames;
     }
 
-    public ArchetypeCreationRequest setFiltereds( List<String> filtereds )
+    public ArchetypeCreationRequest setFilteredFileNames( List<String> filteredFileNames )
     {
-        this.filtereds = filtereds;
+        this.filteredFileNames = filteredFileNames;
+
+        return this;
+    }
+
+    public List<String> getFilteredFileExtensions()
+    {
+        return filteredFileExtensions;
+    }
+
+    public ArchetypeCreationRequest setFilteredFileExtensions( List<String> filteredFileExtensions )
+    {
+        this.filteredFileExtensions = filteredFileExtensions;
 
         return this;
     }

--- a/archetype-common/src/main/java/org/apache/maven/archetype/common/Constants.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/common/Constants.java
@@ -46,6 +46,8 @@ public interface Constants
 
     String ARTIFACT_ID = "artifactId";
 
+    String ARCHETYPE_FILTERED_FILENAMES = "archetype.filteredFileNames";
+
     String ARCHETYPE_FILTERED_EXTENSIONS = "archetype.filteredExtensions";
 
     String ARCHETYPE_LANGUAGES = "archetype.languages";


### PR DESCRIPTION
This commit introduces a new property (archetype.filteredFileNames) which allows users to specify not only filtered file extensions but also comma-separated file-names of files that do not have any extension.