### PR TITLE
[ARCHETYPE-584] fix indentation in root pom.xml

### DIFF
--- a/archetype-common/src/main/java/org/apache/maven/archetype/common/util/PomUtils.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/common/util/PomUtils.java
@@ -82,8 +82,8 @@ public final class PomUtils
         dbf.setXIncludeAware( false );
         dbf.setExpandEntityReferences( false );
 
-        Schema schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
-                .newSchema( new File(PomUtils.class.getClassLoader().getResource("maven-4.0.0.xsd").getFile())) ;
+        Schema schema = SchemaFactory.newInstance( XMLConstants.W3C_XML_SCHEMA_NS_URI )
+                .newSchema( new File( PomUtils.class.getClassLoader().getResource( "maven-4.0.0.xsd" ).getFile() ) );
         dbf.setSchema( schema );
         dbf.setIgnoringElementContentWhitespace( true );
         dbf.setNamespaceAware( true );

--- a/archetype-common/src/main/java/org/apache/maven/archetype/common/util/PomUtils.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/common/util/PomUtils.java
@@ -38,10 +38,11 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
-import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.Reader;
 import java.io.Writer;
 
@@ -82,8 +83,9 @@ public final class PomUtils
         dbf.setXIncludeAware( false );
         dbf.setExpandEntityReferences( false );
 
+        InputStream inputStream = PomUtils.class.getClassLoader().getResourceAsStream( "maven-4.0.0.xsd" );
         Schema schema = SchemaFactory.newInstance( XMLConstants.W3C_XML_SCHEMA_NS_URI )
-                .newSchema( new File( PomUtils.class.getClassLoader().getResource( "maven-4.0.0.xsd" ).getFile() ) );
+                .newSchema( new StreamSource( inputStream ) );
         dbf.setSchema( schema );
         dbf.setIgnoringElementContentWhitespace( true );
         dbf.setNamespaceAware( true );

--- a/archetype-common/src/main/java/org/apache/maven/archetype/common/util/PomUtils.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/common/util/PomUtils.java
@@ -38,6 +38,9 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import java.io.File;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.Writer;
@@ -79,6 +82,12 @@ public final class PomUtils
         dbf.setXIncludeAware( false );
         dbf.setExpandEntityReferences( false );
 
+        Schema schema = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
+                .newSchema( new File(PomUtils.class.getClassLoader().getResource("maven-4.0.0.xsd").getFile())) ;
+        dbf.setSchema( schema );
+        dbf.setIgnoringElementContentWhitespace( true );
+        dbf.setNamespaceAware( true );
+
         DocumentBuilder db = dbf.newDocumentBuilder();
         InputSource inputSource = new InputSource();
         inputSource.setCharacterStream( fileReader );
@@ -114,13 +123,7 @@ public final class PomUtils
                 project.appendChild( modules );
             }
 
-            // shift the child node by next two spaces after the parent node spaces
-            modules.appendChild( document.createTextNode( "  " ) );
-
             modules.appendChild( module );
-
-            // shift the end tag </modules>
-            modules.appendChild( document.createTextNode( "\n  " ) );
 
             TransformerFactory tf = TransformerFactory.newInstance();
             tf.setAttribute( XMLConstants.ACCESS_EXTERNAL_DTD, "" );

--- a/archetype-common/src/main/resources/maven-4.0.0.xsd
+++ b/archetype-common/src/main/resources/maven-4.0.0.xsd
@@ -1,0 +1,2246 @@
+<?xml version="1.0"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" targetNamespace="http://maven.apache.org/POM/4.0.0" xmlns="http://maven.apache.org/POM/4.0.0">
+    <xs:element name="project" type="Model">
+        <xs:annotation>
+            <xs:documentation source="version">3.0.0+</xs:documentation>
+            <xs:documentation source="description">
+                The &lt;code&gt;&amp;lt;project&amp;gt;&lt;/code&gt; element is the root of the descriptor.
+                The following table lists all of the possible child elements.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:element>
+    <xs:complexType name="Model">
+        <xs:annotation>
+            <xs:documentation source="version">3.0.0+</xs:documentation>
+            <xs:documentation source="description">
+                The &lt;code&gt;&amp;lt;project&amp;gt;&lt;/code&gt; element is the root of the descriptor.
+                The following table lists all of the possible child elements.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="parent" minOccurs="0" type="Parent">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The location of the parent project, if one exists. Values from the
+                        parent project will be the default for this project if they are
+                        left unspecified. The location is given as a group ID, artifact ID and version.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="modelVersion" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">Declares to which version of project descriptor this POM conforms.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="groupId" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        A universally unique identifier for a project. It is normal to
+                        use a fully-qualified package name to distinguish it from other projects with a similar name
+                        (eg. &lt;code&gt;org.apache.maven&lt;/code&gt;).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="artifactId" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The identifier for this artifact that is unique within the group given by the group ID.
+                        An artifact is something that is either produced or used by a project. Examples of artifacts produced by
+                        Maven for a project include: JARs, source and binary distributions, and WARs.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="packaging" minOccurs="0" type="xs:string" default="jar">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The type of artifact this project produces, for example &lt;code&gt;jar&lt;/code&gt;
+                        &lt;code&gt;war&lt;/code&gt;
+                        &lt;code&gt;ear&lt;/code&gt;
+                        &lt;code&gt;pom&lt;/code&gt;.
+                        Plugins can create their own packaging, and
+                        therefore their own packaging types,
+                        so this list does not contain all possible types.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The full name of the project.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="version" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The current version of the artifact produced by this project.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="description" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        A detailed description of the project, used by Maven whenever it needs to describe the project,
+                        such as on the web site. While this element can be specified as CDATA to enable
+                        the use of HTML tags within the description, it is discouraged to allow plain text representation.
+                        If you need to modify the index page of the generated web site, you are able to specify your own instead
+                        of adjusting this text.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The URL to the project&apos;s homepage.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="prerequisites" minOccurs="0" type="Prerequisites">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Describes the prerequisites in the build environment for this project.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="issueManagement" minOccurs="0" type="IssueManagement">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The project&apos;s issue management system information.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="ciManagement" minOccurs="0" type="CiManagement">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The project&apos;s continuous integration information.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="inceptionYear" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The year of the project&apos;s inception, specified with 4 digits.
+                        This value is used when generating copyright notices as well as being informational.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="mailingLists" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        Contains information about a project&apos;s mailing lists.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="mailingList" minOccurs="0" maxOccurs="unbounded" type="MailingList"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="developers" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        Describes the committers of a project.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="developer" minOccurs="0" maxOccurs="unbounded" type="Developer"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="contributors" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        Describes the contributors to a project that are not yet committers.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="contributor" minOccurs="0" maxOccurs="unbounded" type="Contributor"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="licenses" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        This element describes all of the licenses for this project.
+                        Each license is described by a &lt;code&gt;license&lt;/code&gt; element, which
+                        is then described by additional elements.
+                        Projects should only list the license(s) that applies to the project
+                        and not the licenses that apply to dependencies.
+                        If multiple licenses are listed, it is assumed that the user can select any of them, not that they
+                        must accept all.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="license" minOccurs="0" maxOccurs="unbounded" type="License"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="scm" minOccurs="0" type="Scm">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Specification for the SCM used by the project, such as CVS, Subversion, etc.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="organization" minOccurs="0" type="Organization">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        This element describes various attributes of the organization to
+                        which the project belongs.  These attributes are utilized when
+                        documentation is created (for copyright notices and links).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="build" minOccurs="0" type="Build">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">Information required to build the project.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="profiles" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        A listing of project-local build profiles which will modify the build process when activated.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="profile" minOccurs="0" maxOccurs="unbounded" type="Profile"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="modules" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The modules (sometimes called subprojects) to build as a part of this project.
+                        Each module listed is a relative path to the directory containing the module.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="module" minOccurs="0" maxOccurs="unbounded" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="repositories" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The lists of the remote repositories for discovering dependencies and
+                        extensions.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="repository" minOccurs="0" maxOccurs="unbounded" type="Repository"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="pluginRepositories" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The lists of the remote repositories for discovering plugins for builds and reports.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="pluginRepository" minOccurs="0" maxOccurs="unbounded" type="Repository"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="dependencies" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        This element describes all of the dependencies associated with a
+                        project.
+                        These dependencies are used to construct a classpath for your
+                        project during the build process. They are automatically downloaded from the
+                        repositories defined in this project.
+                        See &lt;a href=&quot;http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html&quot;&gt;the
+                        dependency mechanism&lt;/a&gt; for more information.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="dependency" minOccurs="0" maxOccurs="unbounded" type="Dependency"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="reports" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        &lt;b&gt;Deprecated&lt;/b&gt;. Now ignored by Maven.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="reporting" minOccurs="0" type="Reporting">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        This element includes the specification of report plugins to use to generate the reports on the
+                        Maven-generated site.  These reports will be run when a user executes &lt;code&gt;mvn site&lt;/code&gt;.  All of the
+                        reports will be included in the navigation bar for browsing.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="dependencyManagement" minOccurs="0" type="DependencyManagement">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Default dependency information for projects that inherit from
+                        this one. The dependencies in this section are not immediately resolved.
+                        Instead, when a POM derived from this one declares a dependency
+                        described by a matching groupId and artifactId, the version and other values from this
+                        section are used for that dependency if they were not already specified.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="distributionManagement" minOccurs="0" type="DistributionManagement">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">Distribution information for a project that enables deployment of the site
+                        and artifacts to remote web servers and repositories respectively.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Properties that can be used throughout the POM as a substitution, and are used as filters in resources
+                        if enabled. The format is &lt;code&gt;&amp;lt;name&amp;gt;value&amp;lt;/name&amp;gt;&lt;/code&gt;.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="Contributor">
+        <xs:annotation>
+            <xs:documentation source="version">3.0.0+</xs:documentation>
+            <xs:documentation source="description">
+                Description of a person who has contributed to the project, but who does
+                not have commit privileges. Usually, these contributions come in the
+                form of patches submitted.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="name" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">The full name of the contributor.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="email" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">The email address of the contributor.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">The URL for the homepage of the contributor.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="organization" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">The organization to which the contributor belongs.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="organizationUrl" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">The URL of the organization.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="roles" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The roles the contributor plays in the project.  Each role is
+                        described by a &lt;code&gt;role&lt;/code&gt; element, the body of which is a
+                        role name. This can also be used to describe the contribution.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="role" minOccurs="0" maxOccurs="unbounded" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="timezone" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The timezone the contributor is in. This is a number in the range -11 to 12.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        Properties about the contributor, such as an instant messenger handle.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="Profile">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+            <xs:documentation source="description">
+                Modifications to the build process which is activated based on environmental parameters or command line arguments.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="id" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The identifier of this build profile. This used both for command line activation, and identifies
+                        identical profiles to merge with during inheritance.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="activation" minOccurs="0" type="Activation">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The conditional logic which will automatically
+                        trigger the inclusion of this profile.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="build" minOccurs="0" type="BuildBase">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">Information required to build the project.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="modules" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The modules (sometimes called subprojects) to build as a part of this project.
+                        Each module listed is a relative path to the directory containing the module.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="module" minOccurs="0" maxOccurs="unbounded" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="repositories" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The lists of the remote repositories for discovering dependencies and
+                        extensions.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="repository" minOccurs="0" maxOccurs="unbounded" type="Repository"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="pluginRepositories" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The lists of the remote repositories for discovering plugins for builds and reports.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="pluginRepository" minOccurs="0" maxOccurs="unbounded" type="Repository"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="dependencies" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        This element describes all of the dependencies associated with a
+                        project.
+                        These dependencies are used to construct a classpath for your
+                        project during the build process. They are automatically downloaded from the
+                        repositories defined in this project.
+                        See &lt;a href=&quot;http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html&quot;&gt;the
+                        dependency mechanism&lt;/a&gt; for more information.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="dependency" minOccurs="0" maxOccurs="unbounded" type="Dependency"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="reports" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        &lt;b&gt;Deprecated&lt;/b&gt;. Now ignored by Maven.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="reporting" minOccurs="0" type="Reporting">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        This element includes the specification of report plugins to use to generate the reports on the
+                        Maven-generated site.  These reports will be run when a user executes &lt;code&gt;mvn site&lt;/code&gt;.  All of the
+                        reports will be included in the navigation bar for browsing.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="dependencyManagement" minOccurs="0" type="DependencyManagement">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Default dependency information for projects that inherit from
+                        this one. The dependencies in this section are not immediately resolved.
+                        Instead, when a POM derived from this one declares a dependency
+                        described by a matching groupId and artifactId, the version and other values from this
+                        section are used for that dependency if they were not already specified.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="distributionManagement" minOccurs="0" type="DistributionManagement">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">Distribution information for a project that enables deployment of the site
+                        and artifacts to remote web servers and repositories respectively.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Properties that can be used throughout the POM as a substitution, and are used as filters in resources
+                        if enabled. The format is &lt;code&gt;&amp;lt;name&amp;gt;value&amp;lt;/name&amp;gt;&lt;/code&gt;.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="Activation">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+            <xs:documentation source="description">
+                The conditions within the build runtime environment which will trigger
+                the automatic inclusion of the build profile.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="activeByDefault" minOccurs="0" type="xs:boolean" default="false">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">Flag specifying whether this profile is active by default.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="jdk" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Specifies that this profile will be activated when a matching JDK is detected. For example, &lt;code&gt;1.4&lt;/code&gt;
+                        only activates on JDKs versioned 1.4, while &lt;code&gt;!1.4&lt;/code&gt; matches any JDK that is not version 1.4.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="os" minOccurs="0" type="ActivationOS">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Specifies that this profile will be activated when matching operating system attributes are detected.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="property" minOccurs="0" type="ActivationProperty">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Specifies that this profile will be activated when this system property is specified.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="file" minOccurs="0" type="ActivationFile">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Specifies that this profile will be activated based on existence of a file.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="ActivationFile">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+            <xs:documentation source="description">
+                This is the file specification used to activate the profile. The missing value will be the location
+                of a file that needs to exist, and if it doesn&apos;t the profile will be activated.  On the other hand exists will test
+                for the existence of the file and if it is there the profile will be activated.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="missing" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The name of the file that must be missing to activate the profile.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="exists" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The name of the file that must exist to activate the profile.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="ActivationProperty">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+            <xs:documentation source="description">
+                This is the property specification used to activate a profile. If the value field is empty,
+                then the existence of the named property will activate the profile, otherwise it does a case-sensitive
+                match against the property value as well.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="name" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The name of the property to be used to activate a profile.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="value" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The value of the property required to activate a profile.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="ActivationOS">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+            <xs:documentation source="description">
+                This is an activator which will detect an operating system&apos;s attributes in order to activate
+                its profile.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="name" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The name of the operating system to be used to activate the profile. This must be an exact match
+                        of the &lt;code&gt;${os.name}&lt;/code&gt; Java property, such as &lt;code&gt;Windows XP&lt;/code&gt;.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="family" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The general family of the OS to be used to activate the profile, such as &lt;code&gt;windows&lt;/code&gt; or &lt;code&gt;unix&lt;/code&gt;.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="arch" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The architecture of the operating system to be used to activate the profile.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="version" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The version of the operating system to be used to activate the profile.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="DependencyManagement">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+            <xs:documentation source="description">
+                Section for management of default dependency information for use in a group of POMs.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="dependencies" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The dependencies specified here are not used until they
+                        are referenced in a POM within the group. This allows the
+                        specification of a &quot;standard&quot; version for a particular
+                        dependency.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="dependency" minOccurs="0" maxOccurs="unbounded" type="Dependency"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="Dependency">
+        <xs:annotation>
+            <xs:documentation source="version">3.0.0+</xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="groupId" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The project group that produced the dependency, e.g.
+                        &lt;code&gt;org.apache.maven&lt;/code&gt;.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="artifactId" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The unique id for an artifact produced by the project group, e.g.
+                        &lt;code&gt;maven-artifact&lt;/code&gt;.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="version" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The version of the dependency, e.g. &lt;code&gt;3.2.1&lt;/code&gt;. In Maven 2, this can also be
+                        specified as a range of versions.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="type" minOccurs="0" type="xs:string" default="jar">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The type of dependency. This defaults to &lt;code&gt;jar&lt;/code&gt;. While it usually represents the extension on
+                        the filename of the dependency, that is not always the case. A type can be mapped to a different
+                        extension and a classifier.
+                        The type often correspongs to the packaging used, though this is also not always the case.
+                        Some examples are &lt;code&gt;jar&lt;/code&gt;, &lt;code&gt;war&lt;/code&gt;, &lt;code&gt;ejb-client&lt;/code&gt; and &lt;code&gt;test-jar&lt;/code&gt;.
+                        New types can be defined by plugins that set
+                        &lt;code&gt;extensions&lt;/code&gt; to &lt;code&gt;true&lt;/code&gt;, so this is not a complete list.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="classifier" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The classifier of the dependency. This allows distinguishing two artifacts that belong to the same POM but
+                        were built differently, and is appended to the filename after the version. For example,
+                        &lt;code&gt;jdk14&lt;/code&gt; and &lt;code&gt;jdk15&lt;/code&gt;.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="scope" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The scope of the dependency - &lt;code&gt;compile&lt;/code&gt;, &lt;code&gt;runtime&lt;/code&gt;, &lt;code&gt;test&lt;/code&gt;,
+                        &lt;code&gt;system&lt;/code&gt;, and &lt;code&gt;provided&lt;/code&gt;. Used to
+                        calculate the various classpaths used for compilation, testing, and so on. It also assists in determining
+                        which artifacts to include in a distribution of this project. For more information, see
+                        &lt;a href=&quot;http://maven.apache.org/guides/introduction/introduction-to-dependency-mechanism.html&quot;&gt;the
+                        dependency mechanism&lt;/a&gt;.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="systemPath" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        FOR SYSTEM SCOPE ONLY. Note that use of this property is &lt;b&gt;discouraged&lt;/b&gt; and may be replaced in later
+                        versions. This specifies the path on the filesystem for this dependency.
+                        Requires an absolute path for the value, not relative.
+                        Use a property that gives the machine specific absolute path,
+                        e.g. &lt;code&gt;${java.home}&lt;/code&gt;.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="exclusions" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Lists a set of artifacts that should be excluded from this dependency&apos;s artifact list when it comes to
+                        calculating transitive dependencies.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="exclusion" minOccurs="0" maxOccurs="unbounded" type="Exclusion"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="optional" minOccurs="0" type="xs:boolean" default="false">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Indicates the dependency is optional for use of this library. While the version of the dependency will be
+                        taken into account for dependency calculation if the library is used elsewhere, it will not be passed on
+                        transitively.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="Exclusion">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="artifactId" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The artifact ID of the project to exclude.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="groupId" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The group ID of the project to exclude.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="Reporting">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+            <xs:documentation source="description">Section for management of reports and their configuration.</xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="excludeDefaults" minOccurs="0" type="xs:boolean" default="false">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">If true, then the default reports are not included in the site generation. This includes the
+                        reports in the &quot;Project Info&quot; menu.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="outputDirectory" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Where to store all of the generated reports. The default is
+                        &lt;code&gt;${project.build.directory}/site&lt;/code&gt;
+                        .
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="plugins" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The reporting plugins to use and their configuration.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="plugin" minOccurs="0" maxOccurs="unbounded" type="ReportPlugin"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="ReportPlugin">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="groupId" minOccurs="0" type="xs:string" default="org.apache.maven.plugins">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The group ID of the reporting plugin in the repository.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="artifactId" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The artifact ID of the reporting plugin in the repository.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="version" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The version of the reporting plugin to be used.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="inherited" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">Whether the configuration in this plugin should be made available to projects that
+                        inherit from this one.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="configuration" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The configuration of the reporting plugin.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+                    </xs:sequence>
+
+                    <!-- These attributes are not exist in the original schema.  -->
+                    <xs:attribute name="combine.children" type="xs:string"/>
+                    <xs:attribute name="combine.self" type="xs:string"/>
+
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="reportSets" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">Multiple specifications of a set of reports, each having (possibly) different
+                        configuration. This is the reporting parallel to an &lt;code&gt;execution&lt;/code&gt; in the build.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="reportSet" minOccurs="0" maxOccurs="unbounded" type="ReportSet"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="ReportSet">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+            <xs:documentation source="description">Represents a set of reports and configuration to be used to generate them.</xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="id" minOccurs="0" type="xs:string" default="default">
+                <xs:annotation>
+                    <xs:documentation source="version">0.0.0+</xs:documentation>
+                    <xs:documentation source="description">The unique id for this report set, to be used during POM inheritance.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="configuration" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">Configuration of the report to be used when generating this set.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="inherited" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Whether any configuration should be propagated to child POMs.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="reports" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The list of reports from this plugin which should be generated from this set.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="report" minOccurs="0" maxOccurs="unbounded" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="BuildBase">
+        <xs:annotation>
+            <xs:documentation source="version">3.0.0+</xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="defaultGoal" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The default goal (or phase in Maven 2) to execute when none is specified for the project.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="resources" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        This element describes all of the classpath resources such as properties files associated with a
+                        project. These resources are often included in the final package.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="resource" minOccurs="0" maxOccurs="unbounded" type="Resource"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="testResources" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        This element describes all of the classpath resources such as properties files associated with a
+                        project&apos;s unit tests.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="testResource" minOccurs="0" maxOccurs="unbounded" type="Resource"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="directory" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The directory where all files generated by the build are placed.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="finalName" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The filename (excluding the extension, and with no path information) that the produced artifact
+                        will be called. The default value is &lt;code&gt;${artifactId}-${version}&lt;/code&gt;.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="filters" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The list of filter properties files that are used when filtering is enabled.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="filter" minOccurs="0" maxOccurs="unbounded" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="pluginManagement" minOccurs="0" type="PluginManagement">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Default plugin information to be made available for reference by
+                        projects derived from this one. This plugin configuration will not
+                        be resolved or bound to the lifecycle unless referenced. Any local
+                        configuration for a given plugin will override the plugin&apos;s entire
+                        definition here.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="plugins" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The list of plugins to use.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="plugin" minOccurs="0" maxOccurs="unbounded" type="Plugin"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="Plugin">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="groupId" minOccurs="0" type="xs:string" default="org.apache.maven.plugins">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The group ID of the plugin in the repository.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="artifactId" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The artifact ID of the plugin in the repository.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="version" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The version (or valid range of verisons) of the plugin to be used.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="extensions" minOccurs="0" type="xs:boolean" default="false">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">Whether to load Maven extensions (such as packaging and type handlers) from this
+                        plugin. For performance reasons, this should only be enabled when necessary.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="executions" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">Multiple specifications of a set of goals to execute during the build lifecycle, each having
+                        (possibly) different
+                        configuration.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="execution" minOccurs="0" maxOccurs="unbounded" type="PluginExecution"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="dependencies" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">Additional dependencies that this project needs to introduce to the plugin&apos;s
+                        classloader.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="dependency" minOccurs="0" maxOccurs="unbounded" type="Dependency"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="goals" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        &lt;b&gt;Deprecated&lt;/b&gt;. Unused by Maven.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="inherited" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Whether any configuration should be propagated to child POMs.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="configuration" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">0.0.0+</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+                    </xs:sequence>
+
+                    <!-- These attributes are not exist in the original schema.  -->
+                    <xs:attribute name="combine.children" type="xs:string"/>
+                    <xs:attribute name="combine.self" type="xs:string"/>
+
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="PluginExecution">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="id" minOccurs="0" type="xs:string" default="default">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The identifier of this execution for labelling the goals during the build, and for matching
+                        exections to merge during inheritance.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="phase" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The build lifecycle phase to bind the goals in this execution to. If omitted, the goals will
+                        be bound to the default specified in their metadata.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="goals" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The goals to execute with the given configuration.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="goal" minOccurs="0" maxOccurs="unbounded" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="inherited" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Whether any configuration should be propagated to child POMs.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="configuration" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">0.0.0+</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+                    </xs:sequence>
+
+                    <!-- These attributes are not exist in the original schema.  -->
+                    <xs:attribute name="combine.children" type="xs:string"/>
+                    <xs:attribute name="combine.self" type="xs:string"/>
+
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="PluginManagement">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+            <xs:documentation source="description">
+                Section for management of default plugin information for use in a group of POMs.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="plugins" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The list of plugins to use.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="plugin" minOccurs="0" maxOccurs="unbounded" type="Plugin"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="Resource">
+        <xs:annotation>
+            <xs:documentation source="version">3.0.0+</xs:documentation>
+            <xs:documentation source="description">
+                This element describes all of the classpath resources associated with a project or
+                unit tests.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="targetPath" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        Describe the resource target path. For example, if you want that
+                        resource to appear in a specific package
+                        (&lt;code&gt;org.apache.maven.messages&lt;/code&gt;), you must specify this
+                        element with this value: &lt;code&gt;org/apache/maven/messages&lt;/code&gt;.
+                        This is not required if you simply put the resources in that directory structure at the source, however.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="filtering" minOccurs="0" type="xs:boolean" default="false">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        Whether resources are filtered to replace tokens with parameterised values or not.
+                        The values are taken from the &lt;code&gt;properties&lt;/code&gt; element and from the properties in the files listed
+                        in the &lt;code&gt;filters&lt;/code&gt; element.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="directory" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        Describe the directory where the resources are stored.
+                        The path is relative to the POM.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="includes" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">A list of patterns to include, e.g. &lt;code&gt;**&amp;#47;*.xml&lt;/code&gt;.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="include" minOccurs="0" maxOccurs="unbounded" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="excludes" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">A list of patterns to exclude, e.g. &lt;code&gt;**&amp;#47;*.xml&lt;/code&gt;</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="exclude" minOccurs="0" maxOccurs="unbounded" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="DistributionManagement">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+            <xs:documentation source="description">
+                This elements describes all that pertains to distribution for a project.
+                It is primarily used for deployment of artifacts and the site
+                produced by the build.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="repository" minOccurs="0" type="DeploymentRepository">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Information needed to deploy the artifacts generated by the project to a remote repository.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="snapshotRepository" minOccurs="0" type="DeploymentRepository">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Where to deploy snapshots of artifacts to. If not given, it defaults to the &lt;code&gt;repository&lt;/code&gt; element.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="site" minOccurs="0" type="Site">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Information needed for deploying the web site of the project.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="downloadUrl" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The URL of the project&apos;s download page. If not given users will be referred to the homepage given by
+                        &lt;code&gt;url&lt;/code&gt;. This is given to assist in locating artifacts that are not in the repository due to
+                        licensing restrictions.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="relocation" minOccurs="0" type="Relocation">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Relocation information of the artifact if it has been moved to a new group ID and/or artifact ID.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="status" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Gives the status of this artifact in the remote repository. This must not be set in your local
+                        project, as it is updated by tools placing it in the reposiory. Valid values are: &lt;code&gt;none&lt;/code&gt; (default),
+                        &lt;code&gt;converted&lt;/code&gt; (repository manager converted this from an Maven 1 POM), &lt;code&gt;partner&lt;/code&gt;
+                        (directly synced from a partner Maven 2 repository), &lt;code&gt;deployed&lt;/code&gt; (was deployed from a Maven 2
+                        instance), &lt;code&gt;verified&lt;/code&gt; (has been hand verified as correct and final).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="Site">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+            <xs:documentation source="description">
+                Contains the information needed for deploying websites.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="id" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        A unique identifier for a deployment locataion. This is used to match the site to configuration in
+                        the &lt;code&gt;settings.xml&lt;/code&gt; file, for example.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Human readable name of the deployment location.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The url of the location where website is deployed, in the form &lt;code&gt;protocol://hostname/path&lt;/code&gt;.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="Relocation">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+            <xs:documentation source="description">Describes where an artifact has moved to. If any of the values are omitted, it is assumed to be the
+                same as it was before.</xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="groupId" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The group ID the artifact has moved to.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="artifactId" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The new artifact ID of the artifact.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="version" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The new version of the artifact.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="message" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">An additional message to show the user about the move, such as the reason.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="DeploymentRepository">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+            <xs:documentation source="description">
+                Repository contains the information needed for deploying to the remote repoistory.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="uniqueVersion" minOccurs="0" type="xs:boolean" default="true">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">Whether to assign snapshots a unique version comprised of the timestamp and build number, or to
+                        use the same version each time</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="id" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        A unique identifier for a repository. This is used to match the repository to configuration in
+                        the &lt;code&gt;settings.xml&lt;/code&gt; file, for example.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Human readable name of the repository.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The url of the repository, in the form &lt;code&gt;protocol://hostname/path&lt;/code&gt;.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="layout" minOccurs="0" type="xs:string" default="default">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The type of layout this repository uses for locating and storing artifacts - can be &lt;code&gt;legacy&lt;/code&gt; or
+                        &lt;code&gt;default&lt;/code&gt;.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="Repository">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+            <xs:documentation source="description">
+                A repository contains the information needed for establishing connections with remote repoistory.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="releases" minOccurs="0" type="RepositoryPolicy">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">How to handle downloading of releases from this repository.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="snapshots" minOccurs="0" type="RepositoryPolicy">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">How to handle downloading of snapshots from this repository.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="id" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        A unique identifier for a repository. This is used to match the repository to configuration in
+                        the &lt;code&gt;settings.xml&lt;/code&gt; file, for example.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Human readable name of the repository.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The url of the repository, in the form &lt;code&gt;protocol://hostname/path&lt;/code&gt;.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="layout" minOccurs="0" type="xs:string" default="default">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The type of layout this repository uses for locating and storing artifacts - can be &lt;code&gt;legacy&lt;/code&gt; or
+                        &lt;code&gt;default&lt;/code&gt;.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="RepositoryPolicy">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+            <xs:documentation source="description">Download policy</xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="enabled" minOccurs="0" type="xs:boolean" default="true">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">Whether to use this repository for downloading this type of artifact.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="updatePolicy" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The frequency for downloading updates - can be
+                        &lt;code&gt;always,&lt;/code&gt;
+                        &lt;code&gt;daily&lt;/code&gt;
+                        (default),
+                        &lt;code&gt;interval:XXX&lt;/code&gt;
+                        (in minutes) or
+                        &lt;code&gt;never&lt;/code&gt;
+                        (only if it doesn&apos;t exist locally).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="checksumPolicy" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        What to do when verification of an artifact checksum fails. Valid values are
+                        &lt;code&gt;ignore&lt;/code&gt;
+                        ,
+                        &lt;code&gt;fail&lt;/code&gt;
+                        or
+                        &lt;code&gt;warn&lt;/code&gt;
+                        (the default).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="MailingList">
+        <xs:annotation>
+            <xs:documentation source="version">3.0.0+</xs:documentation>
+            <xs:documentation source="description">
+                This element describes all of the mailing lists associated with
+                a project. The auto-generated site references this information.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="name" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">The name of the mailing list.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="subscribe" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The email address or link that can be used to subscribe to the mailing list.
+                        If this is an email address, a
+                        &lt;code&gt;mailto:&lt;/code&gt; link will automatically be created when
+                        the documentation is created.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="unsubscribe" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The email address or link that can be used to unsubscribe to
+                        the mailing list.  If this is an email address, a
+                        &lt;code&gt;mailto:&lt;/code&gt; link will automatically be created
+                        when the documentation is created.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="post" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The email address or link that can be used to post to
+                        the mailing list.  If this is an email address, a
+                        &lt;code&gt;mailto:&lt;/code&gt; link will automatically be created
+                        when the documentation is created.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="archive" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The link to a URL where you can browse the mailing list archive.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="otherArchives" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The link to alternate URLs where you can browse the list archive.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="otherArchive" minOccurs="0" maxOccurs="unbounded" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="Build">
+        <xs:annotation>
+            <xs:documentation source="version">3.0.0+</xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="sourceDirectory" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        This element specifies a directory containing the source
+                        of the project. The generated build system will compile
+                        the source in this directory when the project is built.
+                        The path given is relative to the project descriptor.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="scriptSourceDirectory" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        This element specifies a directory containing the script sources
+                        of the project. This directory is meant to be different from the
+                        sourceDirectory, in that its contents will be copied to the output
+                        directory in most cases (since scripts are interpreted rather than
+                        compiled).
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="testSourceDirectory" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        This element specifies a directory containing the unit test
+                        source of the project. The generated build system will
+                        compile these directories when the project is being tested.
+                        The path given is relative to the project descriptor.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="outputDirectory" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The directory where compiled application classes are placed.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="testOutputDirectory" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The directory where compiled test classes are placed.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="extensions" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">A set of build extensions to use from this project.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="extension" minOccurs="0" maxOccurs="unbounded" type="Extension"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="defaultGoal" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The default goal (or phase in Maven 2) to execute when none is specified for the project.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="resources" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        This element describes all of the classpath resources such as properties files associated with a
+                        project. These resources are often included in the final package.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="resource" minOccurs="0" maxOccurs="unbounded" type="Resource"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="testResources" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        This element describes all of the classpath resources such as properties files associated with a
+                        project&apos;s unit tests.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="testResource" minOccurs="0" maxOccurs="unbounded" type="Resource"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="directory" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The directory where all files generated by the build are placed.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="finalName" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The filename (excluding the extension, and with no path information) that the produced artifact
+                        will be called. The default value is &lt;code&gt;${artifactId}-${version}&lt;/code&gt;.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="filters" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The list of filter properties files that are used when filtering is enabled.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="filter" minOccurs="0" maxOccurs="unbounded" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="pluginManagement" minOccurs="0" type="PluginManagement">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Default plugin information to be made available for reference by
+                        projects derived from this one. This plugin configuration will not
+                        be resolved or bound to the lifecycle unless referenced. Any local
+                        configuration for a given plugin will override the plugin&apos;s entire
+                        definition here.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="plugins" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The list of plugins to use.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="plugin" minOccurs="0" maxOccurs="unbounded" type="Plugin"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="Extension">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+            <xs:documentation source="description">Describes a build extension to utilise.</xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="groupId" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The group ID of the extension&apos;s artifact.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="artifactId" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The artifact ID of the extension.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="version" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The version of the extension.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="IssueManagement">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+            <xs:documentation source="description">
+                Information about the issue tracking (or bug tracking) system used to manage this project.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="system" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The name of the issue management system, e.g. Bugzilla</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">URL for the issue management system used by the project.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="Parent">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="artifactId" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The artifact id of the parent project to inherit from.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="groupId" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The group id of the parent project to inherit from.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="version" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The version of the parent project to inherit.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="relativePath" minOccurs="0" type="xs:string" default="../pom.xml">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The relative path of the parent &lt;code&gt;pom.xml&lt;/code&gt; file within the check out.
+                        The default value is &lt;code&gt;../pom.xml&lt;/code&gt;.
+                        Maven looks for the parent pom first in the reactor of currently building projects, then in this location on
+                        the filesystem, then the local repository, and lastly in the remote repo.
+                        &lt;code&gt;relativePath&lt;/code&gt; allows you to select a different location,
+                        for example when your structure is flat, or deeper without an intermediate parent pom.
+                        However, the group ID, artifact ID and version are still required,
+                        and must match the file in the location given or it will revert to the repository for the POM.
+                        This feature is only for enhancing the development in a local checkout of that project.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="Prerequisites">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+            <xs:documentation source="description">Describes the prerequisites a project can have.</xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="maven" minOccurs="0" type="xs:string" default="2.0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The minimum version of Maven required to build the project, or to use this plugin.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="CiManagement">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="system" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The name of the continuous integration system, e.g. &lt;code&gt;continuum&lt;/code&gt;.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        URL for the continuous integration system used by the project if it has a web interface.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="notifiers" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Configuration for notifying developers/users when a build is
+                        unsuccessful, including user information and notification mode.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="notifier" minOccurs="0" maxOccurs="unbounded" type="Notifier"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="Notifier">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+            <xs:documentation source="description">
+                Configures one method for notifying users/developers when a build breaks.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="type" minOccurs="0" type="xs:string" default="mail">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">The mechanism used to deliver notifications.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="sendOnError" minOccurs="0" type="xs:boolean" default="true">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">Whether to send notifications on error.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="sendOnFailure" minOccurs="0" type="xs:boolean" default="true">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">Whether to send notifications on failure.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="sendOnSuccess" minOccurs="0" type="xs:boolean" default="true">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">Whether to send notifications on success.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="sendOnWarning" minOccurs="0" type="xs:boolean" default="true">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">Whether to send notifications on warning.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="address" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        &lt;b&gt;Deprecated&lt;/b&gt;. Where to send the notification to - eg email address.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="configuration" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">0.0.0+</xs:documentation>
+                    <xs:documentation source="description">Extended configuration specific to this notifier goes here.</xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="License">
+        <xs:annotation>
+            <xs:documentation source="version">3.0.0+</xs:documentation>
+            <xs:documentation source="description">
+                Describes the licenses for this project.  This is used to generate
+                the license page of the project&apos;s web site, as well as being taken into consideration in other reporting and
+                validation. The licenses listed for the project are that of the project itself, and not of dependencies.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="name" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">The full legal name of the license.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">The official url for the license text.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="distribution" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The primary method by which this project may be distributed.
+                        &lt;dl&gt;
+                        &lt;dt&gt;repo&lt;/dt&gt;
+                        &lt;dd&gt;may be downloaded from the Maven repository&lt;/dd&gt;
+                        &lt;dt&gt;manual&lt;/dt&gt;
+                        &lt;dd&gt;user must manually download and install the dependency.&lt;/dd&gt;
+                        &lt;/dl&gt;
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="comments" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        Addendum information pertaining to this license.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="Developer">
+        <xs:annotation>
+            <xs:documentation source="version">3.0.0+</xs:documentation>
+            <xs:documentation source="description">
+                Information about one of the committers on this project.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="id" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">The unique ID of the developer in the SCM.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="name" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">The full name of the contributor.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="email" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">The email address of the contributor.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">The URL for the homepage of the contributor.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="organization" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">The organization to which the contributor belongs.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="organizationUrl" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">The URL of the organization.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="roles" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The roles the contributor plays in the project.  Each role is
+                        described by a &lt;code&gt;role&lt;/code&gt; element, the body of which is a
+                        role name. This can also be used to describe the contribution.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="role" minOccurs="0" maxOccurs="unbounded" type="xs:string"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="timezone" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        The timezone the contributor is in. This is a number in the range -11 to 12.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="properties" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">
+                        Properties about the contributor, such as an instant messenger handle.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="Scm">
+        <xs:annotation>
+            <xs:documentation source="version">4.0.0</xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="connection" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The source control management system URL
+                        that describes the repository and how to connect to the
+                        repository. For more information, see the
+                        &lt;a href=&quot;http://maven.apache.org/scm/scm-url-format.html&quot;&gt;URL format&lt;/a&gt;
+                        and &lt;a href=&quot;http://maven.apache.org/scm/scms-overview.html&quot;&gt;list of supported SCMs&lt;/a&gt;.
+                        This connection is read-only.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="developerConnection" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        Just like &lt;code&gt;connection&lt;/code&gt;, but for developers, i.e. this scm connection
+                        will not be read only.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="tag" minOccurs="0" type="xs:string" default="HEAD">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The tag of current code. By default, it&apos;s set to HEAD during development.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">4.0.0</xs:documentation>
+                    <xs:documentation source="description">
+                        The URL to the project&apos;s browsable SCM repository, such as ViewVC or Fisheye.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+    <xs:complexType name="Organization">
+        <xs:annotation>
+            <xs:documentation source="version">3.0.0+</xs:documentation>
+            <xs:documentation source="description">Specifies the organization that produces this project.</xs:documentation>
+        </xs:annotation>
+        <xs:all>
+            <xs:element name="name" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">The full name of the organization.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="url" minOccurs="0" type="xs:string">
+                <xs:annotation>
+                    <xs:documentation source="version">3.0.0+</xs:documentation>
+                    <xs:documentation source="description">The URL to the organization&apos;s home page.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:all>
+    </xs:complexType>
+</xs:schema>

--- a/archetype-common/src/test/java/org/apache/maven/archetype/old/ArchetypeTest.java
+++ b/archetype-common/src/test/java/org/apache/maven/archetype/old/ArchetypeTest.java
@@ -61,18 +61,10 @@ import static org.xmlunit.matchers.CompareMatcher.isIdenticalTo;
 public class ArchetypeTest
     extends PlexusTestCase
 {
-    private static final String XML_VERSION_1_0 =
-            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n";
-    private static final String PROJECT_ELEMENT = "<project " +
-            "xmlns=\"http://maven.apache.org/POM/4.0.0\" " +
-            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
-            "xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 " +
-            "http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n";
-    private static final String PROJECT_ELEMENT_END = "</project>";
-    private static final String MODEL_VERSION = "  <modelVersion>4.0.0</modelVersion>\n";
-    private static final String PACKAGING = "  <packaging>pom</packaging>\n";
 
     private OldArchetype archetype;
+
+    private StringWriter out;
 
     public void testArchetype()
         throws Exception
@@ -253,103 +245,139 @@ public class ArchetypeTest
     public void testAddModuleToParentBasic()
             throws Exception
     {
-        String pom = PROJECT_ELEMENT
-                + PACKAGING
-                + PROJECT_ELEMENT_END;
+        String pom = ("<project " +
+                "xmlns=\"http://maven.apache.org/POM/4.0.0\" " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+                "xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 " +
+                "http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n")
+                + "  <packaging>pom</packaging>\n"
+                + "</project>";
 
-        StringWriter out = new StringWriter();
+        out = new StringWriter();
         assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId1", new StringReader( pom ), out ) );
 
-        assertThat( out.toString(), isIdenticalTo( XML_VERSION_1_0
-                + PROJECT_ELEMENT
-                + PACKAGING
+        assertThat( out.toString(), isIdenticalTo( "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
+                + ("<project " +
+                "xmlns=\"http://maven.apache.org/POM/4.0.0\" " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+                "xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 " +
+                "http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n")
+                + "  <packaging>pom</packaging>\n"
                 + "  <modules>\n"
                 + "    <module>myArtifactId1</module>\n"
                 + "  </modules>\n"
-                + PROJECT_ELEMENT_END ) );
+                + "</project>") );
     }
 
     public void testAddModuleToParentWithModelVersion()
             throws Exception
     {
-        String pom = PROJECT_ELEMENT
-                + MODEL_VERSION
-                + PACKAGING
-                + PROJECT_ELEMENT_END;
+        String pom = ("<project " +
+                "xmlns=\"http://maven.apache.org/POM/4.0.0\" " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+                "xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 " +
+                "http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n")
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "</project>";
 
-        StringWriter out = new StringWriter();
+        out = new StringWriter();
         assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId2", new StringReader( pom ), out ) );
 
-        assertThat( out.toString(), isIdenticalTo( XML_VERSION_1_0
-                + PROJECT_ELEMENT
-                + MODEL_VERSION
-                + PACKAGING
+        assertThat( out.toString(), isIdenticalTo( "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
+                + ("<project " +
+                "xmlns=\"http://maven.apache.org/POM/4.0.0\" " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+                "xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 " +
+                "http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n")
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <packaging>pom</packaging>\n"
                 + "  <modules>\n"
                 + "    <module>myArtifactId2</module>\n"
                 + "  </modules>\n"
-                + PROJECT_ELEMENT_END ) );
+                + "</project>") );
     }
 
     public void testAddModuleToParentWithEmptyModulesElement()
             throws Exception
     {
-        String pom = PROJECT_ELEMENT
-                + MODEL_VERSION
-                + PACKAGING
+        String pom = ("<project " +
+                "xmlns=\"http://maven.apache.org/POM/4.0.0\" " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+                "xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 " +
+                "http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n")
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <packaging>pom</packaging>\n"
                 + "  <modules>\n"
                 + "  </modules>\n"
-                + PROJECT_ELEMENT_END;
+                + "</project>";
 
-        StringWriter out = new StringWriter();
+        out = new StringWriter();
         assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId3", new StringReader( pom ), out ) );
 
-        assertThat( out.toString(), isIdenticalTo( XML_VERSION_1_0
-                + PROJECT_ELEMENT
-                + MODEL_VERSION
-                + PACKAGING
-                + "  <modules>\n"
-                + "    <module>myArtifactId3</module>\n"
-                + "  </modules>\n"
-                + PROJECT_ELEMENT_END ) );
-    }
-
-    public void testAddModuleToParentWithOneModulePresent()
-            throws Exception
-    {
-        String pom = PROJECT_ELEMENT
-                + MODEL_VERSION
-                + PACKAGING
-                + "  <modules>\n"
-                + "    <module>myArtifactId3</module>\n"
-                + "  </modules>\n"
-                + PROJECT_ELEMENT_END;
-
-        StringWriter out = new StringWriter();
-        assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId4", new StringReader( pom ), out ) );
-
-        assertThat( out.toString(), isIdenticalTo( XML_VERSION_1_0
-                + PROJECT_ELEMENT
-                + MODEL_VERSION
-                + PACKAGING
-                + "  <modules>\n"
-                + "    <module>myArtifactId3</module>\n"
-                + "    <module>myArtifactId4</module>\n"
-                + "  </modules>\n"
-                + PROJECT_ELEMENT_END ) );
-    }
-
-    public void testAddModuleToParentDoesNothingWhenSameModuleAdded()
-            throws Exception
-    {
-        String pom = PROJECT_ELEMENT
+        assertThat( out.toString(), isIdenticalTo( "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
+                + ("<project " +
+                "xmlns=\"http://maven.apache.org/POM/4.0.0\" " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+                "xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 " +
+                "http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n")
                 + "  <modelVersion>4.0.0</modelVersion>\n"
                 + "  <packaging>pom</packaging>\n"
                 + "  <modules>\n"
                 + "    <module>myArtifactId3</module>\n"
                 + "  </modules>\n"
-                + PROJECT_ELEMENT_END;
+                + "</project>") );
+    }
 
-        StringWriter out = new StringWriter();
+    public void testAddModuleToParentWithOneModulePresent()
+            throws Exception
+    {
+        String pom = ("<project " +
+                "xmlns=\"http://maven.apache.org/POM/4.0.0\" " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+                "xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 " +
+                "http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n")
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules>\n"
+                + "    <module>myArtifactId3</module>\n"
+                + "  </modules>\n"
+                + "</project>";
+
+        out = new StringWriter();
+        assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId4", new StringReader( pom ), out ) );
+
+        assertThat( out.toString(), isIdenticalTo( "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
+                + ("<project " +
+                "xmlns=\"http://maven.apache.org/POM/4.0.0\" " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+                "xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 " +
+                "http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n")
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules>\n"
+                + "    <module>myArtifactId3</module>\n"
+                + "    <module>myArtifactId4</module>\n"
+                + "  </modules>\n"
+                + "</project>") );
+    }
+
+    public void testAddModuleToParentDoesNothingWhenSameModuleAdded()
+            throws Exception
+    {
+        String pom = ("<project " +
+                "xmlns=\"http://maven.apache.org/POM/4.0.0\" " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+                "xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 " +
+                "http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n")
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules>\n"
+                + "    <module>myArtifactId3</module>\n"
+                + "  </modules>\n"
+                + "</project>";
+
+        out = new StringWriter();
         assertFalse( DefaultOldArchetype.addModuleToParentPom( "myArtifactId3", new StringReader( pom ), out ) );
 
         // empty means unchanged
@@ -359,9 +387,13 @@ public class ArchetypeTest
     public void testAddModuleToParentWithProfiles()
             throws Exception
     {
-        String pom = PROJECT_ELEMENT
-                + MODEL_VERSION
-                + PACKAGING
+        String pom = ("<project " +
+                "xmlns=\"http://maven.apache.org/POM/4.0.0\" " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+                "xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 " +
+                "http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n")
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <packaging>pom</packaging>\n"
                 + "  <modules>\n"
                 + "    <module>myArtifactId1</module>\n"
                 + "    <module>myArtifactId2</module>\n"
@@ -381,15 +413,19 @@ public class ArchetypeTest
                 + "      </modules>\n"
                 + "    </profile>\n"
                 + "  </profiles>\n" +
-                PROJECT_ELEMENT_END;
+                "</project>";
 
-        StringWriter out = new StringWriter();
+        out = new StringWriter();
         assertTrue( DefaultOldArchetype.addModuleToParentPom( "module1", new StringReader( pom ), out ) );
 
-        assertThat( out.toString(), isIdenticalTo(XML_VERSION_1_0
-                + PROJECT_ELEMENT
-                + MODEL_VERSION
-                + PACKAGING
+        assertThat( out.toString(), isIdenticalTo("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
+                + ("<project " +
+                "xmlns=\"http://maven.apache.org/POM/4.0.0\" " +
+                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+                "xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 " +
+                "http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n")
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <packaging>pom</packaging>\n"
                 + "  <modules>\n"
                 + "    <module>myArtifactId1</module>\n"
                 + "    <module>myArtifactId2</module>\n"
@@ -410,7 +446,7 @@ public class ArchetypeTest
                 + "      </modules>\n"
                 + "    </profile>\n"
                 + "  </profiles>\n"
-                + PROJECT_ELEMENT_END ) );
+                + "</project>") );
     }
 
     public void testAddModuleToParentPOMNoPackaging()
@@ -453,5 +489,6 @@ public class ArchetypeTest
     {
         super.setUp();
         archetype = (OldArchetype) lookup( OldArchetype.ROLE );
+        out = new StringWriter();
     }
 }

--- a/archetype-common/src/test/java/org/apache/maven/archetype/old/ArchetypeTest.java
+++ b/archetype-common/src/test/java/org/apache/maven/archetype/old/ArchetypeTest.java
@@ -64,7 +64,7 @@ public class ArchetypeTest
 
     private OldArchetype archetype;
 
-    private StringWriter out;
+    private StringWriter out = new StringWriter();;
 
     public void testArchetype()
         throws Exception
@@ -483,6 +483,5 @@ public class ArchetypeTest
     {
         super.setUp();
         archetype = (OldArchetype) lookup( OldArchetype.ROLE );
-        out = new StringWriter();
     }
 }

--- a/archetype-common/src/test/java/org/apache/maven/archetype/old/ArchetypeTest.java
+++ b/archetype-common/src/test/java/org/apache/maven/archetype/old/ArchetypeTest.java
@@ -61,6 +61,15 @@ import static org.xmlunit.matchers.CompareMatcher.isIdenticalTo;
 public class ArchetypeTest
     extends PlexusTestCase
 {
+    private static final String XML_VERSION_1_0 =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n";
+    private static final String PROJECT_ELEMENT = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" " +
+            "xmlns:xsi=\"http://www.w3" +
+            ".org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven" +
+            ".apache.org/xsd/maven-4.0.0.xsd\">\n";
+    private static final String MODEL_VERSION = "  <modelVersion>4.0.0</modelVersion>\n";
+    private static final String PACKAGING = "  <packaging>pom</packaging>\n";
+
     private OldArchetype archetype;
 
     public void testArchetype()
@@ -239,93 +248,118 @@ public class ArchetypeTest
         return archetypeJarLoader;
     }
 
-    public void testAddModuleToParentPOM()
-        throws Exception
+    public void testAddModuleToParentBasic()
+            throws Exception
     {
-        String pom = "<project>\n"
-            + "  <packaging>pom</packaging>\n"
-            + "</project>";
+        String pom = PROJECT_ELEMENT +
+                PACKAGING;
 
         StringWriter out = new StringWriter();
-        assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId1", new StringReader( pom ), out ) );
+        StringReader fileReader = new StringReader( pom + "</project>" );
+        assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId1", fileReader, out ) );
 
-        assertThat( out.toString(), isIdenticalTo( "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
-                + "<project>\n"
-                + "  <packaging>pom</packaging>\n"
+        assertThat( out.toString(), isIdenticalTo( XML_VERSION_1_0
+                + PROJECT_ELEMENT
+                + PACKAGING
                 + "  <modules>\n"
                 + "    <module>myArtifactId1</module>\n"
                 + "  </modules>\n"
-                + "</project>" ).normalizeWhitespace() );
+                + "</project>" ) );
+    }
 
-        pom = "<project>\n"
-            + "  <modelVersion>4.0.0</modelVersion>\n"
-            + "  <packaging>pom</packaging>\n"
-            + "</project>";
+    public void testAddModuleToParentWithModelVersion()
+            throws Exception
+    {
+        String pom = PROJECT_ELEMENT
+                + MODEL_VERSION
+                + PACKAGING;
 
-        out = new StringWriter();
-        assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId2", new StringReader( pom ), out ) );
+        StringWriter out = new StringWriter();
+        StringReader fileReader = new StringReader( pom + "</project>" );
+        assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId2", fileReader, out ) );
 
-        assertThat( out.toString(), isIdenticalTo( "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
-                + "<project>\n"
-                + "  <modelVersion>4.0.0</modelVersion>\n"
-                + "  <packaging>pom</packaging>\n"
+        assertThat( out.toString(), isIdenticalTo( XML_VERSION_1_0
+                + PROJECT_ELEMENT
+                + MODEL_VERSION
+                + PACKAGING
                 + "  <modules>\n"
                 + "    <module>myArtifactId2</module>\n"
                 + "  </modules>\n"
-                + "</project>" ).normalizeWhitespace() );
+                + "</project>" ) );
+    }
 
-        pom = "<project><modelVersion>4.0.0</modelVersion>\n"
-            + "  <packaging>pom</packaging>\n"
-            + "  <modules>\n"
-            + "  </modules>\n"
-            + "</project>";
+    public void testAddModuleToParentWithEmptyModulesElement()
+            throws Exception
+    {
+        String pom = PROJECT_ELEMENT
+                + MODEL_VERSION
+                + PACKAGING
+                + "  <modules>\n"
+                + "  </modules>\n";
 
-        out = new StringWriter();
-        assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId3", new StringReader( pom ), out ) );
+        StringWriter out = new StringWriter();
+        StringReader fileReader = new StringReader( pom + "</project>" );
+        assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId3", fileReader, out ) );
 
-        assertThat( out.toString(), isIdenticalTo("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
-                + "<project><modelVersion>4.0.0</modelVersion>\n"
-                + "  <packaging>pom</packaging>\n"
+        assertThat( out.toString(), isIdenticalTo( XML_VERSION_1_0
+                + PROJECT_ELEMENT
+                + MODEL_VERSION
+                + PACKAGING
                 + "  <modules>\n"
                 + "    <module>myArtifactId3</module>\n"
                 + "  </modules>\n"
-                + "</project>" ).normalizeWhitespace() );
+                + "</project>" ) );
+    }
 
-        pom = "<project><modelVersion>4.0.0</modelVersion>\n"
-            + "  <packaging>pom</packaging>\n"
-            + "  <modules>\n"
-            + "    <module>myArtifactId3</module>\n"
-            + "  </modules>\n"
-            + "</project>";
+    public void testAddModuleToParentWithOneModulePresent()
+            throws Exception
+    {
+        String pom = PROJECT_ELEMENT
+                + MODEL_VERSION
+                + PACKAGING
+                + "  <modules>\n"
+                + "    <module>myArtifactId3</module>\n"
+                + "  </modules>\n";
 
-        out = new StringWriter();
-        assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId4", new StringReader( pom ), out ) );
+        StringWriter out = new StringWriter();
+        StringReader fileReader = new StringReader( pom + "</project>" );
+        assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId4", fileReader, out ) );
 
-        assertThat( out.toString(), isIdenticalTo("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
-                + "<project><modelVersion>4.0.0</modelVersion>\n"
-                + "  <packaging>pom</packaging>\n"
+        assertThat( out.toString(), isIdenticalTo( XML_VERSION_1_0
+                + PROJECT_ELEMENT
+                + MODEL_VERSION
+                + PACKAGING
                 + "  <modules>\n"
                 + "    <module>myArtifactId3</module>\n"
                 + "    <module>myArtifactId4</module>\n"
                 + "  </modules>\n"
-                + "</project>" ).normalizeWhitespace() );
+                + "</project>" ) );
+    }
 
-        pom = "<project><modelVersion>4.0.0</modelVersion>\n"
-            + "  <packaging>pom</packaging>\n"
-            + "  <modules>\n"
-            + "    <module>myArtifactId3</module>\n"
-            + "  </modules>\n"
-            + "</project>";
+    public void testAddModuleToParentDoesNothingWhenSameModuleAdded()
+            throws Exception
+    {
+        String pom = PROJECT_ELEMENT
+                + "  <modelVersion>4.0.0</modelVersion>\n"
+                + "  <packaging>pom</packaging>\n"
+                + "  <modules>\n"
+                + "    <module>myArtifactId3</module>\n"
+                + "  </modules>\n";
 
-        out = new StringWriter();
-        assertFalse( DefaultOldArchetype.addModuleToParentPom( "myArtifactId3", new StringReader( pom ), out ) );
+        StringWriter out = new StringWriter();
+        StringReader fileReader = new StringReader( pom + "</project>" );
+        assertFalse( DefaultOldArchetype.addModuleToParentPom( "myArtifactId3", fileReader, out ) );
 
         // empty means unchanged
         assertEquals( "", out.toString().trim() );
+    }
 
-
-        pom = "<project><modelVersion>4.0.0</modelVersion>\n"
-                + "  <packaging>pom</packaging>\n"
+    public void testAddModuleToParentWithProfiles()
+            throws Exception
+    {
+        String pom = PROJECT_ELEMENT
+                + MODEL_VERSION
+                + PACKAGING
                 + "  <modules>\n"
                 + "    <module>myArtifactId1</module>\n"
                 + "    <module>myArtifactId2</module>\n"
@@ -347,12 +381,14 @@ public class ArchetypeTest
                 + "  </profiles>\n"
                 + "</project>";
 
-        out = new StringWriter();
-        assertTrue( DefaultOldArchetype.addModuleToParentPom( "module1", new StringReader( pom ), out ) );
+        StringWriter out = new StringWriter();
+        StringReader fileReader = new StringReader( pom );
+        assertTrue( DefaultOldArchetype.addModuleToParentPom( "module1", fileReader, out ) );
 
-        assertThat( out.toString(), isIdenticalTo("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
-                + "<project><modelVersion>4.0.0</modelVersion>\n"
-                + "  <packaging>pom</packaging>\n"
+        assertThat( out.toString(), isIdenticalTo(XML_VERSION_1_0
+                + PROJECT_ELEMENT
+                + MODEL_VERSION
+                + PACKAGING
                 + "  <modules>\n"
                 + "    <module>myArtifactId1</module>\n"
                 + "    <module>myArtifactId2</module>\n"
@@ -373,7 +409,7 @@ public class ArchetypeTest
                 + "      </modules>\n"
                 + "    </profile>\n"
                 + "  </profiles>\n"
-                + "</project>" ).normalizeWhitespace() );
+                + "</project>" ) );
     }
 
     public void testAddModuleToParentPOMNoPackaging()

--- a/archetype-common/src/test/java/org/apache/maven/archetype/old/ArchetypeTest.java
+++ b/archetype-common/src/test/java/org/apache/maven/archetype/old/ArchetypeTest.java
@@ -253,7 +253,6 @@ public class ArchetypeTest
                 + "  <packaging>pom</packaging>\n"
                 + "</project>";
 
-        out = new StringWriter();
         assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId1", new StringReader( pom ), out ) );
 
         assertThat( out.toString(), isIdenticalTo( "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
@@ -281,7 +280,6 @@ public class ArchetypeTest
                 + "  <packaging>pom</packaging>\n"
                 + "</project>";
 
-        out = new StringWriter();
         assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId2", new StringReader( pom ), out ) );
 
         assertThat( out.toString(), isIdenticalTo( "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
@@ -312,7 +310,6 @@ public class ArchetypeTest
                 + "  </modules>\n"
                 + "</project>";
 
-        out = new StringWriter();
         assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId3", new StringReader( pom ), out ) );
 
         assertThat( out.toString(), isIdenticalTo( "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
@@ -344,7 +341,6 @@ public class ArchetypeTest
                 + "  </modules>\n"
                 + "</project>";
 
-        out = new StringWriter();
         assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId4", new StringReader( pom ), out ) );
 
         assertThat( out.toString(), isIdenticalTo( "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"
@@ -377,7 +373,6 @@ public class ArchetypeTest
                 + "  </modules>\n"
                 + "</project>";
 
-        out = new StringWriter();
         assertFalse( DefaultOldArchetype.addModuleToParentPom( "myArtifactId3", new StringReader( pom ), out ) );
 
         // empty means unchanged
@@ -415,7 +410,6 @@ public class ArchetypeTest
                 + "  </profiles>\n" +
                 "</project>";
 
-        out = new StringWriter();
         assertTrue( DefaultOldArchetype.addModuleToParentPom( "module1", new StringReader( pom ), out ) );
 
         assertThat( out.toString(), isIdenticalTo("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n"

--- a/archetype-common/src/test/java/org/apache/maven/archetype/old/ArchetypeTest.java
+++ b/archetype-common/src/test/java/org/apache/maven/archetype/old/ArchetypeTest.java
@@ -63,10 +63,12 @@ public class ArchetypeTest
 {
     private static final String XML_VERSION_1_0 =
             "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>\n";
-    private static final String PROJECT_ELEMENT = "<project xmlns=\"http://maven.apache.org/POM/4.0.0\" " +
-            "xmlns:xsi=\"http://www.w3" +
-            ".org/2001/XMLSchema-instance\" xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 http://maven" +
-            ".apache.org/xsd/maven-4.0.0.xsd\">\n";
+    private static final String PROJECT_ELEMENT = "<project " +
+            "xmlns=\"http://maven.apache.org/POM/4.0.0\" " +
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" " +
+            "xsi:schemaLocation=\"http://maven.apache.org/POM/4.0.0 " +
+            "http://maven.apache.org/xsd/maven-4.0.0.xsd\">\n";
+    private static final String PROJECT_ELEMENT_END = "</project>";
     private static final String MODEL_VERSION = "  <modelVersion>4.0.0</modelVersion>\n";
     private static final String PACKAGING = "  <packaging>pom</packaging>\n";
 
@@ -251,12 +253,12 @@ public class ArchetypeTest
     public void testAddModuleToParentBasic()
             throws Exception
     {
-        String pom = PROJECT_ELEMENT +
-                PACKAGING;
+        String pom = PROJECT_ELEMENT
+                + PACKAGING
+                + PROJECT_ELEMENT_END;
 
         StringWriter out = new StringWriter();
-        StringReader fileReader = new StringReader( pom + "</project>" );
-        assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId1", fileReader, out ) );
+        assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId1", new StringReader( pom ), out ) );
 
         assertThat( out.toString(), isIdenticalTo( XML_VERSION_1_0
                 + PROJECT_ELEMENT
@@ -264,7 +266,7 @@ public class ArchetypeTest
                 + "  <modules>\n"
                 + "    <module>myArtifactId1</module>\n"
                 + "  </modules>\n"
-                + "</project>" ) );
+                + PROJECT_ELEMENT_END ) );
     }
 
     public void testAddModuleToParentWithModelVersion()
@@ -272,11 +274,11 @@ public class ArchetypeTest
     {
         String pom = PROJECT_ELEMENT
                 + MODEL_VERSION
-                + PACKAGING;
+                + PACKAGING
+                + PROJECT_ELEMENT_END;
 
         StringWriter out = new StringWriter();
-        StringReader fileReader = new StringReader( pom + "</project>" );
-        assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId2", fileReader, out ) );
+        assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId2", new StringReader( pom ), out ) );
 
         assertThat( out.toString(), isIdenticalTo( XML_VERSION_1_0
                 + PROJECT_ELEMENT
@@ -285,7 +287,7 @@ public class ArchetypeTest
                 + "  <modules>\n"
                 + "    <module>myArtifactId2</module>\n"
                 + "  </modules>\n"
-                + "</project>" ) );
+                + PROJECT_ELEMENT_END ) );
     }
 
     public void testAddModuleToParentWithEmptyModulesElement()
@@ -295,11 +297,11 @@ public class ArchetypeTest
                 + MODEL_VERSION
                 + PACKAGING
                 + "  <modules>\n"
-                + "  </modules>\n";
+                + "  </modules>\n"
+                + PROJECT_ELEMENT_END;
 
         StringWriter out = new StringWriter();
-        StringReader fileReader = new StringReader( pom + "</project>" );
-        assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId3", fileReader, out ) );
+        assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId3", new StringReader( pom ), out ) );
 
         assertThat( out.toString(), isIdenticalTo( XML_VERSION_1_0
                 + PROJECT_ELEMENT
@@ -308,7 +310,7 @@ public class ArchetypeTest
                 + "  <modules>\n"
                 + "    <module>myArtifactId3</module>\n"
                 + "  </modules>\n"
-                + "</project>" ) );
+                + PROJECT_ELEMENT_END ) );
     }
 
     public void testAddModuleToParentWithOneModulePresent()
@@ -319,11 +321,11 @@ public class ArchetypeTest
                 + PACKAGING
                 + "  <modules>\n"
                 + "    <module>myArtifactId3</module>\n"
-                + "  </modules>\n";
+                + "  </modules>\n"
+                + PROJECT_ELEMENT_END;
 
         StringWriter out = new StringWriter();
-        StringReader fileReader = new StringReader( pom + "</project>" );
-        assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId4", fileReader, out ) );
+        assertTrue( DefaultOldArchetype.addModuleToParentPom( "myArtifactId4", new StringReader( pom ), out ) );
 
         assertThat( out.toString(), isIdenticalTo( XML_VERSION_1_0
                 + PROJECT_ELEMENT
@@ -333,7 +335,7 @@ public class ArchetypeTest
                 + "    <module>myArtifactId3</module>\n"
                 + "    <module>myArtifactId4</module>\n"
                 + "  </modules>\n"
-                + "</project>" ) );
+                + PROJECT_ELEMENT_END ) );
     }
 
     public void testAddModuleToParentDoesNothingWhenSameModuleAdded()
@@ -344,11 +346,11 @@ public class ArchetypeTest
                 + "  <packaging>pom</packaging>\n"
                 + "  <modules>\n"
                 + "    <module>myArtifactId3</module>\n"
-                + "  </modules>\n";
+                + "  </modules>\n"
+                + PROJECT_ELEMENT_END;
 
         StringWriter out = new StringWriter();
-        StringReader fileReader = new StringReader( pom + "</project>" );
-        assertFalse( DefaultOldArchetype.addModuleToParentPom( "myArtifactId3", fileReader, out ) );
+        assertFalse( DefaultOldArchetype.addModuleToParentPom( "myArtifactId3", new StringReader( pom ), out ) );
 
         // empty means unchanged
         assertEquals( "", out.toString().trim() );
@@ -378,12 +380,11 @@ public class ArchetypeTest
                 + "        <module>module2</module>\n"
                 + "      </modules>\n"
                 + "    </profile>\n"
-                + "  </profiles>\n"
-                + "</project>";
+                + "  </profiles>\n" +
+                PROJECT_ELEMENT_END;
 
         StringWriter out = new StringWriter();
-        StringReader fileReader = new StringReader( pom );
-        assertTrue( DefaultOldArchetype.addModuleToParentPom( "module1", fileReader, out ) );
+        assertTrue( DefaultOldArchetype.addModuleToParentPom( "module1", new StringReader( pom ), out ) );
 
         assertThat( out.toString(), isIdenticalTo(XML_VERSION_1_0
                 + PROJECT_ELEMENT
@@ -409,7 +410,7 @@ public class ArchetypeTest
                 + "      </modules>\n"
                 + "    </profile>\n"
                 + "  </profiles>\n"
-                + "</project>" ) );
+                + PROJECT_ELEMENT_END ) );
     }
 
     public void testAddModuleToParentPOMNoPackaging()


### PR DESCRIPTION
Problem: linebreaks + indentions (whitespaces) are read as actual document nodes. This causes problems in combination with
```
tr.setOutputProperty( OutputKeys.INDENT, "yes" );
tr.setOutputProperty( "{http://xml.apache.org/xslt}indent-amount", "2" );
```

Removed the `.normalizeWhitespace()` in tests, because this shadowed the actual bug. Also split  one test into multiple tests. Test content remains the same.

Had to add the **maven-4.0.0.xsd**, not sure if this is desired.