### PR TITLE
WIP: Add feature no create base dir

### DIFF
--- a/archetype-common/src/main/java/org/apache/maven/archetype/ArchetypeGenerationRequest.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/ArchetypeGenerationRequest.java
@@ -64,6 +64,8 @@ public class ArchetypeGenerationRequest
     private String archetypeVersion;
 
     private String archetypeGoals = "";
+    
+    private boolean createBaseDir = true;
 
     /**
      * The URL to the archetype repository
@@ -388,6 +390,18 @@ public class ArchetypeGenerationRequest
     {
         this.filter = filter;
 
+        return this;
+    }
+    
+    public boolean isCreateBaseDir()
+    {
+        return createBaseDir;
+    }
+    
+    public ArchetypeGenerationRequest setCreteBaseDir( boolean createBaseDir )
+    {
+        this.createBaseDir = createBaseDir;
+        
         return this;
     }
 }

--- a/archetype-common/src/main/java/org/apache/maven/archetype/generator/DefaultFilesetArchetypeGenerator.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/generator/DefaultFilesetArchetypeGenerator.java
@@ -136,7 +136,8 @@ public class DefaultFilesetArchetypeGenerator
 
             String packageName = request.getPackage();
             String artifactId = request.getArtifactId();
-            File outputDirectoryFile = new File( request.getOutputDirectory(), artifactId );
+            File outputDirectoryFile = new File( request.getOutputDirectory(),
+                    request.isCreateBaseDir() ? artifactId : "" );
             File basedirPom = new File( request.getOutputDirectory(), Constants.ARCHETYPE_POM );
             File pom = new File( outputDirectoryFile, Constants.ARCHETYPE_POM );
 

--- a/archetype-common/src/test/java/org/apache/maven/archetype/generator/DefaultArchetypeGeneratorTest.java
+++ b/archetype-common/src/test/java/org/apache/maven/archetype/generator/DefaultArchetypeGeneratorTest.java
@@ -429,6 +429,37 @@ public class DefaultArchetypeGeneratorTest
                     result.getCause().getMessage().startsWith( "Archetype archetypes:basic:1.0 is not configured" )
                         && result.getCause().getMessage().endsWith( "Property property-without-default-4 is missing." ) );
     }
+    
+    public void testGenerateArchetypeWithSameDirectoryExcution()
+            throws Exception
+    {
+        System.out.println( "testGenerateArchetypeWithSameDirectoryExcution" );
+        ArchetypeGenerationRequest request = createArchetypeGenerationRequest( "generate-14", ARCHETYPE_BASIC );
+        request.setCreteBaseDir( false );
+        projectDirectory = new File( outputDirectory );
+        FileUtils.forceDelete( projectDirectory );
+        
+        generateProjectFromArchetype(request);
+        assertTemplateContentGeneratedWithFileSetArchetype( "src/main/java/file/value/package/App.java", "file-value" );
+        assertTemplateContentGeneratedWithFileSetArchetype( "src/main/java/file/value/package/inner/package/App2.java","file-value" );
+    
+        assertTemplateCopiedWithFileSetArchetype( "src/main/java/file/value/package/App.ogg" );
+    
+        File templateFile = new File( projectDirectory, "src/main/java/file/value/package/ToDelete.java" );
+        assertFalse( templateFile + " should have been removed (by post-generate.groovy script", templateFile.exists() );
+    
+        assertTemplateContentGeneratedWithFileSetArchetype( "src/main/resources/App.properties", "file-value" );
+        assertTemplateContentGeneratedWithFileSetArchetype( "src/main/resources/file-value/touch.txt", "file-value" );
+        assertTemplateContentGeneratedWithFileSetArchetype( "src/main/resources/file-value/touch_root.txt",
+                "file-value" );
+    
+        assertTemplateCopiedWithFileSetArchetype( "src/main/resources/some-dir/App.png" );
+    
+        assertTemplateContentGeneratedWithFileSetArchetype( "src/site/site.xml", "file-value" );
+        assertTemplateContentGeneratedWithFileSetArchetype( "src/site/apt/usage.apt", "file-value" );
+        assertTemplateContentGeneratedWithFileSetArchetype( ".classpath", "file-value" );
+        assertTemplateContentGeneratedWithFileSetArchetype( "profiles.xml", "file-value" );
+    }
 
     public void testGenerateArchetypeWithPostScriptIncluded()
         throws Exception


### PR DESCRIPTION
For now when you create an project always generate a directory with the name of the artifact but in some case this is not required.

You can see https://stackoverflow.com/questions/24399613/using-maven-archetype-generate-in-the-same-directory

Work-in-Progress.

If this a bad approach let me know please.