### PR TITLE
(doc) Drop maven version from message

### DIFF
--- a/archetype-common/src/main/java/org/apache/maven/archetype/generator/DefaultFilesetArchetypeGenerator.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/generator/DefaultFilesetArchetypeGenerator.java
@@ -193,7 +193,7 @@ public class DefaultFilesetArchetypeGenerator
                 if ( outputDirectoryFile.exists() && pom.exists() )
                 {
                     throw new ProjectDirectoryExists(
-                        "A Maven 2 project already exists in the directory " + outputDirectoryFile.getPath() );
+                        "A Maven project already exists in the directory " + outputDirectoryFile.getPath() );
                 }
 
                 if ( outputDirectoryFile.exists() )


### PR DESCRIPTION
Given I use archetype with current maven, ie. 3.6.3 (is that Maven 3 then?), that produces pom of modelVersion 4.0.0. Mentioning that version `2` adds third item to the set of versions involved. I find it unnecessary.