### PR TITLE
[ARCHETYPE-605] Allow .gitignore file in archetype resources

### DIFF
--- a/maven-archetype-plugin/src/it/projects/default-excludes/invoker.properties
+++ b/maven-archetype-plugin/src/it/projects/default-excludes/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean package

--- a/maven-archetype-plugin/src/it/projects/default-excludes/pom.xml
+++ b/maven-archetype-plugin/src/it/projects/default-excludes/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.archetype.its</groupId>
+  <artifactId>default-excludes</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>maven-archetype</packaging>
+
+  <name>default-excludes</name>
+  <description>packages an archetype then runs IT (archetype:integration-test)</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.archetype</groupId>
+        <artifactId>archetype-packaging</artifactId>
+        <version>@project.version@</version>
+      </extension>
+    </extensions>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <configuration>
+            <addDefaultExcludes>false</addDefaultExcludes>
+          </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-archetype-plugin</artifactId>
+          <version>@project.version@</version>
+          <configuration>
+            <addDefaultExcludes>false</addDefaultExcludes>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+
+  </build>
+</project>

--- a/maven-archetype-plugin/src/it/projects/default-excludes/setup.groovy
+++ b/maven-archetype-plugin/src/it/projects/default-excludes/setup.groovy
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.nio.file.Files
+import java.nio.file.Path
+
+Path dir = basedir.toPath().resolve( 'src/main/resources/archetype-resources/' )
+Files.createDirectories( dir )
+
+def gitattributes = dir.resolve( '.gitattributes' )
+def content = '# this file should be included if addDefaultExcludes is set to false'
+Files.writeString( gitattributes, content )
+println( 'Created ' + gitattributes )

--- a/maven-archetype-plugin/src/it/projects/default-excludes/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/maven-archetype-plugin/src/it/projects/default-excludes/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<archetype-descriptor xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd"
+    name="default-excludes">
+  <fileSets>
+    <fileSet filtered="false" packaged="false" encoding="UTF-8">
+      <directory>src/main/resources</directory>
+    </fileSet>
+  </fileSets>
+</archetype-descriptor>

--- a/maven-archetype-plugin/src/it/projects/default-excludes/src/main/resources/archetype-resources/pom.xml
+++ b/maven-archetype-plugin/src/it/projects/default-excludes/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,29 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>default.excludes</groupId>
+  <artifactId>default-excludes</artifactId>
+  <version>1.0</version>
+
+</project>

--- a/maven-archetype-plugin/src/it/projects/default-excludes/verify.groovy
+++ b/maven-archetype-plugin/src/it/projects/default-excludes/verify.groovy
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import java.util.jar.JarFile
+
+def artifact = new File( basedir, 'target/default-excludes-1.0-SNAPSHOT.jar' )
+assert artifact.exists()
+
+def jar = new JarFile( artifact )
+def entries = jar.entries().collect { it.getName() }
+assert entries.any {  it == 'archetype-resources/.gitattributes' }

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/JarMojo.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/JarMojo.java
@@ -37,6 +37,7 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.archiver.Archiver;
 import org.codehaus.plexus.archiver.jar.JarArchiver;
+import org.codehaus.plexus.archiver.util.DefaultFileSet;
 
 import java.io.File;
 import java.util.Map;
@@ -55,6 +56,17 @@ public class JarMojo
      */
     @Parameter( defaultValue = "${project.build.outputDirectory}", required = true )
     private File archetypeDirectory;
+
+    /**
+     * By default files like .gitignore, .gitattributes etc. are excluded, which
+     * means they will not be added to the jar. You can add them by setting this
+     * parameter to {@code false}. The files excluded by default are defined by
+     * FileUtils.getDefaultExcludes() in plexus-utils.
+     *
+     * @since 3.3.0
+     */
+    @Parameter( defaultValue = "true", required = true )
+    private boolean addDefaultExcludes;
 
     /**
      * Name of the generated JAR.
@@ -136,7 +148,9 @@ public class JarMojo
 
         try
         {
-            archiver.getArchiver().addDirectory( archetypeDirectory );
+            DefaultFileSet fileSet = new DefaultFileSet( archetypeDirectory );
+            fileSet.setUsingDefaultExcludes( addDefaultExcludes );
+            archiver.getArchiver().addFileSet( fileSet );
 
             archiver.createArchive( session, project, archive );
         }


### PR DESCRIPTION
This change allows to create archetypes with files like .gitignore
that are excluded by default. It adds the parameter
"addDefaultExcludes" to the jar mojo. The parameter can be set to
"false" to allow including default files like .gitignore.
The default is "true" (exclude default files) so the plugin behaves
the same as before when the parameter is not set. The parameter is
named and behaves the same as the one in the plugin
"maven-resources-plugin" which usually also needs to be set when
someone wants to include one of the files excluded by default.

This fixes [ARCHETYPE-605: Allow .gitignore file in archetype resources](https://issues.apache.org/jira/browse/ARCHETYPE-605).