### PR TITLE
[MNG-6965] - Quick fix by adding dependency

### DIFF
--- a/archetype-packaging/pom.xml
+++ b/archetype-packaging/pom.xml
@@ -33,4 +33,25 @@
   <name>Maven Archetype Packaging</name>
   <description>'maven-archetype' packaging configuration for archetypes.</description>
 
+<!-- 
+  All Maven plugins have an implicit dependency on plexus-utils.
+  If no version is explicitly specified, they will have a 
+  dependency on plexus-utils:1.1 injected by 
+  org.apache.maven.plugin.internal.PlexusUtilsInjector.
+  
+  This is an extremely old version, with many known vulnerabilities,
+  so this change makes the dependency explicit in order to
+  respect the parents' dependencyManagement.
+  
+  Better solutions would be to remove that injection or make 
+  it respect the dependencyManagement declarations.
+  
+  See MNG-6965
+ -->
+  <dependencies>
+  	<dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+  	</dependency>
+  </dependencies>
 </project>


### PR DESCRIPTION
This is a quick fix to MNG-6965 by adding an explicit dependency on plexus-utils.

No one seems very interested in fixing it properly and I cannot assess the impact of my two preferred solutions from that Jira ticket, so this is the simplest solution for the time being. In my opinion, it *does not* close MNG-6965.