### PR TITLE
[WIP] A naive attempt to switch to maven 3.1.1

### DIFF
--- a/archetype-common/pom.xml
+++ b/archetype-common/pom.xml
@@ -107,12 +107,8 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-aether-provider</artifactId>
-      <version>3.0</version>
+      <version>3.1.1</version>
       <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-artifact-transfer</artifactId>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -127,10 +123,11 @@
       <artifactId>commons-collections</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.aether</groupId>
+      <groupId>org.eclipse.aether</groupId>
       <artifactId>aether-impl</artifactId>
-      <version>1.7</version>
+      <version>1.1.0</version>
     </dependency>
+
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-velocity</artifactId>
@@ -178,6 +175,19 @@
       <artifactId>xmlunit-matchers</artifactId>
       <scope>test</scope>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/org.eclipse.aether/aether-api -->
+    <dependency>
+      <groupId>org.eclipse.aether</groupId>
+      <artifactId>aether-api</artifactId>
+      <version>0.9.0.M4</version>
+    </dependency>
+    <dependency>
+      <groupId>org.sonatype.aether</groupId>
+      <artifactId>aether-impl</artifactId>
+      <version>1.13.1</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/archetype-common/pom.xml
+++ b/archetype-common/pom.xml
@@ -156,12 +156,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.aether</groupId>
+      <groupId>org.eclipse.aether</groupId>
       <artifactId>aether-connector-file</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.sonatype.aether</groupId>
+      <groupId>org.eclipse.aether</groupId>
       <artifactId>aether-connector-wagon</artifactId>
       <scope>test</scope>
     </dependency>
@@ -175,17 +175,10 @@
       <artifactId>xmlunit-matchers</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- https://mvnrepository.com/artifact/org.eclipse.aether/aether-api -->
     <dependency>
       <groupId>org.eclipse.aether</groupId>
       <artifactId>aether-api</artifactId>
-      <version>0.9.0.M4</version>
-    </dependency>
-    <dependency>
-      <groupId>org.sonatype.aether</groupId>
-      <artifactId>aether-impl</artifactId>
-      <version>1.13.1</version>
-      <scope>test</scope>
+      <version>1.1.0</version>
     </dependency>
 
   </dependencies>

--- a/archetype-common/src/main/java/org/apache/maven/archetype/source/LocalCatalogArchetypeDataSource.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/source/LocalCatalogArchetypeDataSource.java
@@ -19,32 +19,35 @@ package org.apache.maven.archetype.source;
  * under the License.
  */
 
+import org.apache.maven.archetype.catalog.Archetype;
+import org.apache.maven.archetype.catalog.ArchetypeCatalog;
+import org.apache.maven.project.ProjectBuildingRequest;
+import org.codehaus.plexus.component.annotations.Component;
+import org.codehaus.plexus.component.annotations.Requirement;
+import org.codehaus.plexus.util.ReaderFactory;
+import org.eclipse.aether.RepositorySystemSession;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Iterator;
-
-import org.apache.maven.archetype.catalog.Archetype;
-import org.apache.maven.archetype.catalog.ArchetypeCatalog;
-import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.maven.shared.transfer.repository.RepositoryManager;
-
-import org.codehaus.plexus.component.annotations.Component;
-import org.codehaus.plexus.component.annotations.Requirement;
-import org.codehaus.plexus.util.ReaderFactory;
 
 @Component( role = ArchetypeDataSource.class, hint = "catalog" )
 public class LocalCatalogArchetypeDataSource
     extends CatalogArchetypeDataSource
 {
     @Requirement
-    private RepositoryManager repositoryManager;
+    private final RepositorySystemSession session;
+
+    public LocalCatalogArchetypeDataSource(RepositorySystemSession session) {
+        this.session = session;
+    }
 
     @Override
     public void updateCatalog( ProjectBuildingRequest buildingRequest, Archetype archetype )
         throws ArchetypeDataSourceException
     {
-        File localRepo = repositoryManager.getLocalRepositoryBasedir( buildingRequest );
+        File localRepo = session.getLocalRepository().getBasedir();
 
         File catalogFile = new File( localRepo, ARCHETYPE_CATALOG_FILENAME );
 
@@ -105,7 +108,7 @@ public class LocalCatalogArchetypeDataSource
     public ArchetypeCatalog getArchetypeCatalog( ProjectBuildingRequest buildingRequest )
         throws ArchetypeDataSourceException
     {
-        File localRepo = repositoryManager.getLocalRepositoryBasedir( buildingRequest );
+        File localRepo = session.getLocalRepository().getBasedir();
 
         File catalogFile = new File( localRepo, ARCHETYPE_CATALOG_FILENAME );
 

--- a/archetype-common/src/test/java/org/apache/maven/archetype/generator/DefaultArchetypeGeneratorTest.java
+++ b/archetype-common/src/test/java/org/apache/maven/archetype/generator/DefaultArchetypeGeneratorTest.java
@@ -37,10 +37,10 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.maven.repository.internal.MavenRepositorySystemSession;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.sonatype.aether.impl.internal.SimpleLocalRepositoryManager;
 
 public class DefaultArchetypeGeneratorTest
@@ -564,8 +564,8 @@ public class DefaultArchetypeGeneratorTest
         request.setProperties( ADDITIONAL_PROPERTIES );
         
         ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest();
-        MavenRepositorySystemSession repositorySession = new MavenRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( localRepository.getBasedir() ) );
+        DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
+        //repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( localRepository.getBasedir() ) );
         buildingRequest.setRepositorySession( repositorySession );
         request.setProjectBuildingRequest( buildingRequest );
 

--- a/archetype-common/src/test/java/org/apache/maven/archetype/generator/DefaultArchetypeGeneratorTest.java
+++ b/archetype-common/src/test/java/org/apache/maven/archetype/generator/DefaultArchetypeGeneratorTest.java
@@ -41,7 +41,6 @@ import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.ReaderFactory;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.eclipse.aether.DefaultRepositorySystemSession;
-import org.sonatype.aether.impl.internal.SimpleLocalRepositoryManager;
 
 public class DefaultArchetypeGeneratorTest
     extends AbstractMojoTestCase

--- a/archetype-common/src/test/java/org/apache/maven/archetype/old/ArchetypeTest.java
+++ b/archetype-common/src/test/java/org/apache/maven/archetype/old/ArchetypeTest.java
@@ -42,13 +42,13 @@ import org.apache.maven.model.Model;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.maven.repository.internal.MavenRepositorySystemSession;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.context.Context;
 import org.codehaus.plexus.PlexusTestCase;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.codehaus.plexus.velocity.VelocityComponent;
+import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.sonatype.aether.impl.internal.SimpleLocalRepositoryManager;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -89,8 +89,8 @@ public class ArchetypeTest
         
         ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest();
         buildingRequest.setRemoteRepositories( remoteRepositories );
-        MavenRepositorySystemSession repositorySession = new MavenRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( localRepository.getBasedir() ) );
+        DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
+        //repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( localRepository.getBasedir() ) );
         buildingRequest.setRepositorySession( repositorySession );
 
         ArchetypeGenerationRequest request = new ArchetypeGenerationRequest()

--- a/archetype-common/src/test/java/org/apache/maven/archetype/old/ArchetypeTest.java
+++ b/archetype-common/src/test/java/org/apache/maven/archetype/old/ArchetypeTest.java
@@ -49,7 +49,6 @@ import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.codehaus.plexus.velocity.VelocityComponent;
 import org.eclipse.aether.DefaultRepositorySystemSession;
-import org.sonatype.aether.impl.internal.SimpleLocalRepositoryManager;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.xmlunit.matchers.CompareMatcher.isIdenticalTo;

--- a/archetype-common/src/test/java/org/apache/maven/archetype/source/LocalCatalogArchetypeDataSourceTest.java
+++ b/archetype-common/src/test/java/org/apache/maven/archetype/source/LocalCatalogArchetypeDataSourceTest.java
@@ -17,19 +17,20 @@ package org.apache.maven.archetype.source;
  *  under the License.
  */
 
-import java.io.File;
-import java.io.FileWriter;
-import java.io.Writer;
-
 import org.apache.maven.archetype.ArchetypeManager;
 import org.apache.maven.archetype.catalog.Archetype;
 import org.apache.maven.archetype.catalog.ArchetypeCatalog;
 import org.apache.maven.archetype.catalog.io.xpp3.ArchetypeCatalogXpp3Writer;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.maven.repository.internal.MavenRepositorySystemSession;
 import org.codehaus.plexus.PlexusTestCase;
+import org.eclipse.aether.DefaultRepositorySystemSession;
+import org.eclipse.aether.repository.LocalRepositoryManager;
 import org.sonatype.aether.impl.internal.SimpleLocalRepositoryManager;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.Writer;
 
 public class LocalCatalogArchetypeDataSourceTest extends PlexusTestCase
 {
@@ -63,11 +64,12 @@ public class LocalCatalogArchetypeDataSourceTest extends PlexusTestCase
                     throws Exception
     {
         ArchetypeManager archetype = lookup( ArchetypeManager.class );
-
+        DefaultRepositorySystemSession drss = new DefaultRepositorySystemSession();
+        LocalRepositoryManager localRepositoryManager = drss.getLocalRepositoryManager();
         ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest();
-        MavenRepositorySystemSession repositorySession = new MavenRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( getTestFile( "target/test-classes/repositories/test-catalog" ) ) );
-        buildingRequest.setRepositorySession( repositorySession );
+//        MavenRepositorySystemSession repositorySession = new MavenRepositorySystemSession();
+        drss.setLocalRepositoryManager((LocalRepositoryManager) new SimpleLocalRepositoryManager( getTestFile( "target/test-classes/repositories/test-catalog" ) ));
+        buildingRequest.setRepositorySession( drss );
         
         
         ArchetypeCatalog result = archetype.getLocalCatalog( buildingRequest );

--- a/archetype-common/src/test/java/org/apache/maven/archetype/source/LocalCatalogArchetypeDataSourceTest.java
+++ b/archetype-common/src/test/java/org/apache/maven/archetype/source/LocalCatalogArchetypeDataSourceTest.java
@@ -26,7 +26,6 @@ import org.apache.maven.project.ProjectBuildingRequest;
 import org.codehaus.plexus.PlexusTestCase;
 import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.eclipse.aether.repository.LocalRepositoryManager;
-import org.sonatype.aether.impl.internal.SimpleLocalRepositoryManager;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -68,7 +67,7 @@ public class LocalCatalogArchetypeDataSourceTest extends PlexusTestCase
         LocalRepositoryManager localRepositoryManager = drss.getLocalRepositoryManager();
         ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest();
 //        MavenRepositorySystemSession repositorySession = new MavenRepositorySystemSession();
-        drss.setLocalRepositoryManager((LocalRepositoryManager) new SimpleLocalRepositoryManager( getTestFile( "target/test-classes/repositories/test-catalog" ) ));
+//        drss.setLocalRepositoryManager((LocalRepositoryManager) new SimpleLocalRepositoryManager( getTestFile( "target/test-classes/repositories/test-catalog" ) ));
         buildingRequest.setRepositorySession( drss );
         
         

--- a/archetype-common/src/test/java/org/apache/maven/archetype/test/ArchetypeGenerationTest.java
+++ b/archetype-common/src/test/java/org/apache/maven/archetype/test/ArchetypeGenerationTest.java
@@ -22,22 +22,20 @@ package org.apache.maven.archetype.test;
 import org.apache.maven.archetype.ArchetypeGenerationRequest;
 import org.apache.maven.archetype.ArchetypeGenerationResult;
 import org.apache.maven.archetype.ArchetypeManager;
+import org.apache.maven.archetype.catalog.Archetype;
+import org.apache.maven.archetype.catalog.ArchetypeCatalog;
 import org.apache.maven.artifact.repository.ArtifactRepository;
 import org.apache.maven.artifact.repository.ArtifactRepositoryPolicy;
 import org.apache.maven.artifact.repository.MavenArtifactRepository;
 import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.maven.repository.internal.MavenRepositorySystemSession;
 import org.codehaus.plexus.PlexusTestCase;
+import org.codehaus.plexus.util.FileUtils;
+import org.eclipse.aether.DefaultRepositorySystemSession;
 
 import java.io.File;
 import java.util.Properties;
-
-import org.apache.maven.archetype.catalog.Archetype;
-import org.apache.maven.archetype.catalog.ArchetypeCatalog;
-import org.codehaus.plexus.util.FileUtils;
-import org.sonatype.aether.impl.internal.SimpleLocalRepositoryManager;
 
 /** @author Jason van Zyl */
 public class ArchetypeGenerationTest
@@ -56,8 +54,8 @@ public class ArchetypeGenerationTest
                 .toURI().toURL().toExternalForm(), "local-repo" );
         
         ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest();
-        MavenRepositorySystemSession repositorySession = new MavenRepositorySystemSession();
-        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( "target/test-classes/repositories/central" ) );
+        DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
+//        repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( "target/test-classes/repositories/central" ) );
         buildingRequest.setRepositorySession( repositorySession );
 
         ArchetypeCatalog catalog = archetype.getLocalCatalog( buildingRequest );

--- a/archetype-common/src/test/java/org/apache/maven/archetype/test/InternalCatalogArchetypesVerificationTest.java
+++ b/archetype-common/src/test/java/org/apache/maven/archetype/test/InternalCatalogArchetypesVerificationTest.java
@@ -35,7 +35,6 @@ import org.apache.maven.project.ProjectBuildingRequest;
 import org.codehaus.plexus.PlexusTestCase;
 import org.codehaus.plexus.util.FileUtils;
 import org.eclipse.aether.DefaultRepositorySystemSession;
-import org.sonatype.aether.impl.internal.SimpleLocalRepositoryManager;
 
 /**
  *

--- a/archetype-common/src/test/java/org/apache/maven/archetype/test/InternalCatalogArchetypesVerificationTest.java
+++ b/archetype-common/src/test/java/org/apache/maven/archetype/test/InternalCatalogArchetypesVerificationTest.java
@@ -32,9 +32,9 @@ import org.apache.maven.artifact.repository.MavenArtifactRepository;
 import org.apache.maven.artifact.repository.layout.DefaultRepositoryLayout;
 import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.ProjectBuildingRequest;
-import org.apache.maven.repository.internal.MavenRepositorySystemSession;
 import org.codehaus.plexus.PlexusTestCase;
 import org.codehaus.plexus.util.FileUtils;
+import org.eclipse.aether.DefaultRepositorySystemSession;
 import org.sonatype.aether.impl.internal.SimpleLocalRepositoryManager;
 
 /**
@@ -87,8 +87,9 @@ public class InternalCatalogArchetypesVerificationTest
                 .setLocalRepository( localRepository );
             
             ProjectBuildingRequest buildingRequest = new DefaultProjectBuildingRequest();
-            MavenRepositorySystemSession repositorySession = new MavenRepositorySystemSession();
-            repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( localRepository.getBasedir() ) );
+            DefaultRepositorySystemSession repositorySession = new DefaultRepositorySystemSession();
+//            SimpleLocalRepositoryManager slrm = new SimpleLocalRepositoryManager( localRepository.getBasedir();
+//            repositorySession.setLocalRepositoryManager( new SimpleLocalRepositoryManager( localRepository.getBasedir() ) );
             buildingRequest.setRepositorySession( repositorySession );
             request.setProjectBuildingRequest( buildingRequest );
 

--- a/maven-archetype-plugin/pom.xml
+++ b/maven-archetype-plugin/pom.xml
@@ -127,10 +127,6 @@
       <artifactId>maven-invoker</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.apache.maven.shared</groupId>
-      <artifactId>maven-artifact-transfer</artifactId>
-    </dependency>
-    <dependency>
       <groupId>commons-lang</groupId>
       <artifactId>commons-lang</artifactId>
       <version>2.6</version>

--- a/pom.xml
+++ b/pom.xml
@@ -226,14 +226,14 @@
         <version>${wagonVersion}</version>
       </dependency>
       <dependency>
-        <groupId>org.sonatype.aether</groupId>
+        <groupId>org.eclipse.aether</groupId>
         <artifactId>aether-connector-file</artifactId>
-        <version>1.7</version>
+        <version>0.9.0.M2</version>
       </dependency>
       <dependency>
-        <groupId>org.sonatype.aether</groupId>
+        <groupId>org.eclipse.aether</groupId>
         <artifactId>aether-connector-wagon</artifactId>
-        <version>1.7</version>
+        <version>0.9.0.M2</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
 
   <properties>
     <maven.archetype.scm.devConnection>scm:git:https://gitbox.apache.org/repos/asf/maven-archetype.git</maven.archetype.scm.devConnection>
-    <mavenVersion>3.0</mavenVersion>
+    <mavenVersion>3.1.1</mavenVersion>
     <javaVersion>7</javaVersion>
     <netbeans.hint.useExternalMaven>true</netbeans.hint.useExternalMaven>
     <wagonVersion>3.3.3</wagonVersion>
@@ -144,11 +144,6 @@
         <groupId>org.apache.maven.shared</groupId>
         <artifactId>maven-invoker</artifactId>
         <version>3.0.1</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven.shared</groupId>
-        <artifactId>maven-artifact-transfer</artifactId>
-        <version>0.12.0</version>
       </dependency>
       <dependency>
         <groupId>org.codehaus.plexus</groupId>
@@ -280,12 +275,15 @@
     </pluginManagement>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-component-metadata</artifactId>
+        <groupId>org.eclipse.sisu</groupId>
+        <artifactId>sisu-maven-plugin</artifactId>
+        <version>0.3.4</version>
         <executions>
           <execution>
+            <id>index-project</id>
             <goals>
-              <goal>generate-metadata</goal>
+              <goal>main-index</goal>
+              <goal>test-index</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
Looking at https://github.com/apache/maven-artifact-transfer/pull/20#issuecomment-752454346 I thought it might be a good idea to finish switching plugins to Maven 3.1.1 and retire `maven-artifact-transfer` plugin. 

A quick search in apache organization showed several usages: https://github.com/search?p=1&q=maven-artifact-transfer+user%3Aapache+extension%3Axml+path%3A%2F&type=Code

I've followed recommendations from [this page](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=155749857) but it seem to lack some information, maybe it'd be good to extend it.

1) It's not clear whether sisu-maven-plugin's goals replace existing plexus-component-metadata goal.
2) Probably due to 1) `lookup()` method fails with ComponentLookupException
