### PR TITLE
[ARCHETYPE-622] - maven-archetype-plugin integration-test doesn't use…

### DIFF
--- a/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/invoker.properties
+++ b/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = clean integration-test
+invoker.settingsFile = ${basedir}/target/it/projects/ARCHETYPE-622_main_build_settings/test-settings.xml

--- a/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/pom.xml
+++ b/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.apache.maven.plugins.archetype.its</groupId>
+  <artifactId>build-archetype-and-run-its-with-main-build-settings</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>maven-archetype</packaging>
+
+  <name>build-archetype-with-existing-parent</name>
+  <description>packages an archetype then runs IT (archetype:integration-test) within a Maven Project being created through another archetype</description>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.archetype</groupId>
+        <artifactId>archetype-packaging</artifactId>
+        <version>@project.version@</version>
+      </extension>
+    </extensions>
+
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-archetype-plugin</artifactId>
+          <version>@project.version@</version>
+          <configuration>
+            <debug>true</debug>
+            <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+            <ignoreEOLStyle>true</ignoreEOLStyle>
+            <properties>
+              <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
+              <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
+              <!-- e.g. ensure that Java7 picks up TLSv1.2 when connecting with Central -->
+              <https.protocols>${https.protocols}</https.protocols>
+            </properties>
+          </configuration>
+        </plugin>
+        <plugin>
+          <artifactId>maven-resources-plugin</artifactId>
+          <configuration>
+            <includeEmptyDirs>true</includeEmptyDirs>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<archetype-descriptor xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd"
+    name="build-archetype-IT">
+  <fileSets>
+    <fileSet filtered="true" packaged="true" encoding="UTF-8">
+      <directory>src/main/java</directory>
+      <includes>
+        <include>**/*.java</include>
+      </includes>
+    </fileSet>
+  </fileSets>
+</archetype-descriptor>

--- a/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/src/main/resources/archetype-resources/pom.xml
+++ b/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/src/main/resources/archetype-resources/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+## There should be no parent specified, as it should be set automatically
+
+  <groupId>${groupId}</groupId>
+  <artifactId>${artifactId}</artifactId>
+  <version>${version}</version>
+
+  <name>archetype build IT</name>
+
+  <properties>
+    <javaVersion>6</javaVersion>
+    <maven.compiler.source>1.${javaVersion}</maven.compiler.source>
+    <maven.compiler.target>1.${javaVersion}</maven.compiler.target>    
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.7.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/src/main/resources/archetype-resources/src/main/java/App.java
+++ b/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/src/main/resources/archetype-resources/src/main/java/App.java
@@ -1,0 +1,36 @@
+package ${package};
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Hello world!
+ *
+ */
+public class App
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+        System.out.println( "groupId = ${groupId}" );
+        System.out.println( "artifactId = ${artifactId}" );
+        System.out.println( "package = ${package}" );
+        System.out.println( "packageInPathFormat = ${packageInPathFormat}" );
+    }
+}

--- a/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/src/test/resources/projects/basic/archetype.properties
+++ b/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/src/test/resources/projects/basic/archetype.properties
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+version=0.1-SNAPSHOT
+groupId=archetype.it
+artifactId=basic
+package=build.archetype

--- a/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/src/test/resources/projects/basic/goal.txt
+++ b/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/src/test/resources/projects/basic/goal.txt
@@ -1,0 +1,1 @@
+compile

--- a/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/src/test/resources/projects/basic/reference/pom.xml
+++ b/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/src/test/resources/projects/basic/reference/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>archetype.it</groupId>
+  <artifactId>basic</artifactId>
+  <version>0.1-SNAPSHOT</version>
+
+  <name>archetype build IT</name>
+
+  <properties>
+    <javaVersion>6</javaVersion>
+    <maven.compiler.source>1.${javaVersion}</maven.compiler.source>
+    <maven.compiler.target>1.${javaVersion}</maven.compiler.target>    
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.7.0</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>

--- a/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/src/test/resources/projects/basic/reference/src/main/java/build/archetype/App.java
+++ b/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/src/test/resources/projects/basic/reference/src/main/java/build/archetype/App.java
@@ -1,0 +1,36 @@
+package build.archetype;
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/**
+ * Hello world!
+ *
+ */
+public class App
+{
+    public static void main( String[] args )
+    {
+        System.out.println( "Hello World!" );
+        System.out.println( "groupId = archetype.it" );
+        System.out.println( "artifactId = basic" );
+        System.out.println( "package = build.archetype" );
+        System.out.println( "packageInPathFormat = build/archetype" );
+    }
+}

--- a/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/src/test/resources/projects/basic/verify.groovy
+++ b/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/src/test/resources/projects/basic/verify.groovy
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+println( 'Archetype tests executed!' )
+System.out.flush()

--- a/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/test-settings.xml
+++ b/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/test-settings.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<settings>
+  <profiles>
+    <profile>
+      <id>it-repo</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <repositories>
+        <repository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>local.central</id>
+          <url>@localRepositoryUrl@</url>
+          <releases>
+            <enabled>true</enabled>
+          </releases>
+          <snapshots>
+            <enabled>true</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+  </profiles>
+</settings>

--- a/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/verify.bsh
+++ b/maven-archetype-plugin/src/it/projects/ARCHETYPE-622_main_build_settings/verify.bsh
@@ -1,0 +1,63 @@
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import java.io.*;
+import org.codehaus.plexus.util.*;
+
+basedir = new File( basedir, "target/test-classes/projects/basic/project/basic" );
+if ( !basedir.exists() ) {
+	throw new Exception( basedir + " is missing." );
+}
+
+File main = new File( basedir, "src/main" );
+
+// check <fileset packaged="true">
+File app = new File( main, "java/build/archetype/App.java" );
+if ( !app.isFile() )
+{
+    throw new Exception( app + " file is missing or not a file." );
+}
+
+File buildLog = new File( basedir, "build.log" );
+
+String content = FileUtils.fileRead( buildLog, "UTF-8" );
+
+int idx = content.indexOf( "Archetype tests executed!" );
+if ( idx < 0 )
+{
+    throw new Exception( "build.log missing System.out.println from verify.groovy" );
+}
+
+// we expect the archetype:integration-test to use the settings.xml from the main Maven build - so downloading should happen
+// also from local.central specified in the test-settings.xml
+int idx = content.indexOf( "Downloading from local.central: file://" );
+if ( idx <0 )
+{
+    throw new Exception( "test-settings.xml wasn't passed from the main Maven build!: 'Downloading from local.central: file://' was NOT found in the output!" );
+}
+
+String settingsXmlPath = new File("maven-archetype/maven-archetype-plugin/target/it/projects/ARCHETYPE-622_main_build_settings/target/classes/archetype-it", "archetype-settings.xml").toPath().toString();
+settingsXmlPath = settingsXmlPath.replace("\\", "\\\\"); // Windows path handling
+
+boolean usingSettingsFromMainBuild = content.matches("(?s).*\\[DEBUG\\] Reading user settings from .*" + settingsXmlPath + ".*");
+if ( !usingSettingsFromMainBuild )
+{
+    throw new Exception( "test-settings.xml wasn't passed from the main Maven build!: 'Reading user settings from ... archetype-settings.xml' was NOT found in the output!" + content );
+}

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/IntegrationTestMojo.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/IntegrationTestMojo.java
@@ -23,6 +23,7 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileReader;
+import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -56,6 +57,7 @@ import org.apache.maven.project.DefaultProjectBuildingRequest;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.project.ProjectBuildingRequest;
 import org.apache.maven.settings.Settings;
+import org.apache.maven.settings.io.xpp3.SettingsXpp3Writer;
 import org.apache.maven.shared.transfer.artifact.DefaultArtifactCoordinate;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolver;
 import org.apache.maven.shared.transfer.artifact.resolve.ArtifactResolverException;
@@ -662,7 +664,6 @@ public class IntegrationTestMojo
                 request.setProperties( props );
             }
 
-            File interpolatedSettingsFile = null;
             if ( settingsFile != null )
             {
                 File interpolatedSettingsDirectory =
@@ -672,12 +673,34 @@ public class IntegrationTestMojo
                     FileUtils.deleteDirectory( interpolatedSettingsDirectory );
                 }
                 interpolatedSettingsDirectory.mkdir();
-                interpolatedSettingsFile =
+                File interpolatedSettingsFile =
                     new File( interpolatedSettingsDirectory, "interpolated-" + settingsFile.getName() );
 
                 buildInterpolatedFile( settingsFile, interpolatedSettingsFile );
 
                 request.setUserSettingsFile( interpolatedSettingsFile );
+            }
+            else // Use settings coming from the main Maven build
+            {
+                File mainBuildSettingsDirectory =
+                        new File( project.getBuild().getOutputDirectory(), "archetype-it" );
+                mainBuildSettingsDirectory.mkdir();
+                File mainBuildSettingsFile = new File( mainBuildSettingsDirectory, "archetype-settings.xml" );
+
+                SettingsXpp3Writer settingsWriter = new SettingsXpp3Writer();
+
+                try ( FileWriter fileWriter = new FileWriter( mainBuildSettingsFile ) )
+                {
+                    settingsWriter.write( fileWriter, settings );
+                }
+
+                if ( getLog().isDebugEnabled() )
+                {
+                    getLog().debug( "Created archetype-settings.xml with settings from the main Maven build: "
+                                            + mainBuildSettingsFile.getAbsolutePath() );
+                }
+
+                request.setUserSettingsFile( mainBuildSettingsFile );
             }
 
             try


### PR DESCRIPTION
… Maven settings from the main build

[ARCHETYPE-622](https://issues.apache.org/jira/browse/ARCHETYPE-622)

Hi @hboutemy,

can you please look at the PR? I think it may be good to unify the behaviour of maven-archetype-plugin:integration-test with the invoker in terms of settings.xml consumption. Otherwise when one tries to make it behave the same, unnecessary workarounds are needed. I have also included a test which tests that the correct settings were passed to the archetype by checking the download output of the build.

Thanks!