### PR TITLE
[MNG-6829] Replace any StringUtils#isEmpty(String) and #isNotEmpty(String)

### DIFF
--- a/archetype-common/src/main/java/org/apache/maven/archetype/common/DefaultArchetypeFilesResolver.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/common/DefaultArchetypeFilesResolver.java
@@ -71,8 +71,8 @@ public class DefaultArchetypeFilesResolver
     public List<String> filterFiles( String moduleOffset, FileSet fileSet, List<String> archetypeResources )
     {
         ListScanner scanner = new ListScanner();
-        scanner.setBasedir( ( ( moduleOffset == null || moduleOffset.isEmpty() ) ? "" : ( moduleOffset + File.separatorChar ) )
-                                + fileSet.getDirectory() );
+        scanner.setBasedir( ( ( moduleOffset == null || moduleOffset.isEmpty() ) ? ""
+                : ( moduleOffset + File.separatorChar ) ) + fileSet.getDirectory() );
         scanner.setIncludes( fileSet.getIncludes() );
         scanner.setExcludes( fileSet.getExcludes() );
         scanner.setCaseSensitive( true );

--- a/archetype-common/src/main/java/org/apache/maven/archetype/common/DefaultArchetypeFilesResolver.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/common/DefaultArchetypeFilesResolver.java
@@ -71,7 +71,7 @@ public class DefaultArchetypeFilesResolver
     public List<String> filterFiles( String moduleOffset, FileSet fileSet, List<String> archetypeResources )
     {
         ListScanner scanner = new ListScanner();
-        scanner.setBasedir( ( (moduleOffset == null || moduleOffset.isEmpty()) ? "" : ( moduleOffset + File.separatorChar ) )
+        scanner.setBasedir( ( ( moduleOffset == null || moduleOffset.isEmpty() ) ? "" : ( moduleOffset + File.separatorChar ) )
                                 + fileSet.getDirectory() );
         scanner.setIncludes( fileSet.getIncludes() );
         scanner.setExcludes( fileSet.getExcludes() );

--- a/archetype-common/src/main/java/org/apache/maven/archetype/common/DefaultArchetypeFilesResolver.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/common/DefaultArchetypeFilesResolver.java
@@ -71,7 +71,7 @@ public class DefaultArchetypeFilesResolver
     public List<String> filterFiles( String moduleOffset, FileSet fileSet, List<String> archetypeResources )
     {
         ListScanner scanner = new ListScanner();
-        scanner.setBasedir( ( StringUtils.isEmpty( moduleOffset ) ? "" : ( moduleOffset + File.separatorChar ) )
+        scanner.setBasedir( ( (moduleOffset == null || moduleOffset.isEmpty()) ? "" : ( moduleOffset + File.separatorChar ) )
                                 + fileSet.getDirectory() );
         scanner.setIncludes( fileSet.getIncludes() );
         scanner.setExcludes( fileSet.getExcludes() );
@@ -282,7 +282,7 @@ public class DefaultArchetypeFilesResolver
         String common = "";
 
         String difference = StringUtils.difference( packageName, templatePackage );
-        if ( StringUtils.isNotEmpty( difference ) )
+        if ( difference != null && !difference.isEmpty() )
         {
             String temporaryCommon =
                 StringUtils.substring( templatePackage, 0, templatePackage.lastIndexOf( difference ) );

--- a/archetype-common/src/main/java/org/apache/maven/archetype/creator/FilesetArchetypeCreator.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/creator/FilesetArchetypeCreator.java
@@ -1647,7 +1647,7 @@ public class FilesetArchetypeCreator
 
     private void restoreArtifactId( Properties properties, String artifactId )
     {
-        if ( StringUtils.isEmpty( artifactId ) )
+        if ( artifactId == null || artifactId.isEmpty() )
         {
             properties.remove( Constants.ARTIFACT_ID );
         }
@@ -1659,7 +1659,7 @@ public class FilesetArchetypeCreator
 
     private void restoreParentArtifactId( Properties properties, String parentArtifactId )
     {
-        if ( StringUtils.isEmpty( parentArtifactId ) )
+        if ( parentArtifactId == null || parentArtifactId.isEmpty() )
         {
             properties.remove( Constants.PARENT_ARTIFACT_ID );
         }
@@ -1743,7 +1743,7 @@ public class FilesetArchetypeCreator
             }
             else
             {
-                if ( StringUtils.isEmpty( extension ) )
+                if ( extension == null || extension.isEmpty() )
                 {
                     includes.add( "**/*" );
                 }

--- a/archetype-common/src/main/java/org/apache/maven/archetype/generator/DefaultFilesetArchetypeGenerator.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/generator/DefaultFilesetArchetypeGenerator.java
@@ -323,12 +323,12 @@ public class DefaultFilesetArchetypeGenerator
 
     private String getEncoding( String archetypeEncoding )
     {
-        return (archetypeEncoding == null || archetypeEncoding.isEmpty()) ? "UTF-8" : archetypeEncoding;
+        return ( archetypeEncoding == null || archetypeEncoding.isEmpty() ) ? "UTF-8" : archetypeEncoding;
     }
 
     private String getOffsetSeparator( String moduleOffset )
     {
-        return (moduleOffset == null || moduleOffset.isEmpty()) ? "/" : ( "/" + moduleOffset + "/" );
+        return ( moduleOffset == null || moduleOffset.isEmpty() ) ? "/" : ( "/" + moduleOffset + "/" );
     }
 
     private File getOutputFile( String template, String directory, File outputDirectoryFile, boolean packaged,
@@ -569,7 +569,7 @@ public class DefaultFilesetArchetypeGenerator
             processFilesetModule( rootArtifactId, moduleArtifactId,
                                   archetypeResources, new File( moduleOutputDirectoryFile, Constants.ARCHETYPE_POM ),
                                   archetypeZipFile,
-                                  ( (moduleOffset == null || moduleOffset.isEmpty()) ? "" : ( moduleOffset + "/" ) )
+                                  ( ( moduleOffset == null || moduleOffset.isEmpty() ) ? "" : ( moduleOffset + "/" ) )
                                       + StringUtils.replace( project.getDir(), "${rootArtifactId}", rootArtifactId ),
                                   pom, moduleOutputDirectoryFile, packageName, project, context );
         }

--- a/archetype-common/src/main/java/org/apache/maven/archetype/generator/DefaultFilesetArchetypeGenerator.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/generator/DefaultFilesetArchetypeGenerator.java
@@ -323,12 +323,12 @@ public class DefaultFilesetArchetypeGenerator
 
     private String getEncoding( String archetypeEncoding )
     {
-        return StringUtils.isEmpty( archetypeEncoding ) ? "UTF-8" : archetypeEncoding;
+        return (archetypeEncoding == null || archetypeEncoding.isEmpty()) ? "UTF-8" : archetypeEncoding;
     }
 
     private String getOffsetSeparator( String moduleOffset )
     {
-        return StringUtils.isEmpty( moduleOffset ) ? "/" : ( "/" + moduleOffset + "/" );
+        return (moduleOffset == null || moduleOffset.isEmpty()) ? "/" : ( "/" + moduleOffset + "/" );
     }
 
     private File getOutputFile( String template, String directory, File outputDirectoryFile, boolean packaged,
@@ -569,7 +569,7 @@ public class DefaultFilesetArchetypeGenerator
             processFilesetModule( rootArtifactId, moduleArtifactId,
                                   archetypeResources, new File( moduleOutputDirectoryFile, Constants.ARCHETYPE_POM ),
                                   archetypeZipFile,
-                                  ( StringUtils.isEmpty( moduleOffset ) ? "" : ( moduleOffset + "/" ) )
+                                  ( (moduleOffset == null || moduleOffset.isEmpty()) ? "" : ( moduleOffset + "/" ) )
                                       + StringUtils.replace( project.getDir(), "${rootArtifactId}", rootArtifactId ),
                                   pom, moduleOutputDirectoryFile, packageName, project, context );
         }
@@ -778,7 +778,7 @@ public class DefaultFilesetArchetypeGenerator
 
     private void restoreParentArtifactId( Context context, String parentArtifactId )
     {
-        if ( StringUtils.isEmpty( parentArtifactId ) )
+        if ( parentArtifactId == null || parentArtifactId.isEmpty() )
         {
             context.remove( Constants.PARENT_ARTIFACT_ID );
         }

--- a/archetype-common/src/main/java/org/apache/maven/archetype/source/RemoteCatalogArchetypeDataSource.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/source/RemoteCatalogArchetypeDataSource.java
@@ -46,7 +46,6 @@ import org.apache.maven.wagon.repository.Repository;
 import org.codehaus.plexus.component.annotations.Component;
 import org.codehaus.plexus.component.annotations.Requirement;
 import org.codehaus.plexus.util.ReaderFactory;
-import org.codehaus.plexus.util.StringUtils;
 
 /**
  * @author Jason van Zyl
@@ -415,7 +414,7 @@ public class RemoteCatalogArchetypeDataSource extends CatalogArchetypeDataSource
         boolean result = false;
 
         // simple checks first to short circuit processing below.
-        if ( StringUtils.isEmpty( mirrorLayout ) || WILDCARD.equals( mirrorLayout ) )
+        if ( (mirrorLayout == null || mirrorLayout.isEmpty()) || WILDCARD.equals( mirrorLayout ) )
         {
             result = true;
         }

--- a/archetype-common/src/main/java/org/apache/maven/archetype/source/RemoteCatalogArchetypeDataSource.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/source/RemoteCatalogArchetypeDataSource.java
@@ -414,7 +414,7 @@ public class RemoteCatalogArchetypeDataSource extends CatalogArchetypeDataSource
         boolean result = false;
 
         // simple checks first to short circuit processing below.
-        if ( (mirrorLayout == null || mirrorLayout.isEmpty()) || WILDCARD.equals( mirrorLayout ) )
+        if ( ( mirrorLayout == null || mirrorLayout.isEmpty() ) || WILDCARD.equals( mirrorLayout ) )
         {
             result = true;
         }

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/CreateArchetypeFromProjectMojo.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/CreateArchetypeFromProjectMojo.java
@@ -297,7 +297,7 @@ public class CreateArchetypeFromProjectMojo
     {
         List<String> filteredExtensions = new ArrayList<>();
 
-        if ( StringUtils.isNotEmpty( archetypeFilteredExtentions ) )
+        if ( archetypeFilteredExtentions != null && !archetypeFilteredExtentions.isEmpty() )
         {
             filteredExtensions.addAll( Arrays.asList( StringUtils.split( archetypeFilteredExtentions, "," ) ) );
 
@@ -309,7 +309,7 @@ public class CreateArchetypeFromProjectMojo
             Properties properties = PropertyUtils.loadProperties( propertyFile );
 
             String extensions = properties.getProperty( Constants.ARCHETYPE_FILTERED_EXTENSIONS );
-            if ( StringUtils.isNotEmpty( extensions ) )
+            if ( extensions != null && !extensions.isEmpty() )
             {
                 filteredExtensions.addAll( Arrays.asList( StringUtils.split( extensions, "," ) ) );
             }
@@ -331,7 +331,7 @@ public class CreateArchetypeFromProjectMojo
     {
         List<String> resultingLanguages = new ArrayList<>();
 
-        if ( StringUtils.isNotEmpty( archetypeLanguages ) )
+        if ( archetypeLanguages != null && !archetypeLanguages.isEmpty() )
         {
             resultingLanguages.addAll( Arrays.asList( StringUtils.split( archetypeLanguages, "," ) ) );
 
@@ -343,7 +343,7 @@ public class CreateArchetypeFromProjectMojo
             Properties properties = PropertyUtils.loadProperties( propertyFile );
 
             String languages = properties.getProperty( Constants.ARCHETYPE_LANGUAGES );
-            if ( StringUtils.isNotEmpty( languages ) )
+            if ( languages != null && !languages.isEmpty() )
             {
                 resultingLanguages.addAll( Arrays.asList( StringUtils.split( languages, "," ) ) );
             }

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/CreateProjectFromArchetypeMojo.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/CreateProjectFromArchetypeMojo.java
@@ -229,12 +229,12 @@ public class CreateProjectFromArchetypeMojo
 
         String postArchetypeGenerationGoals = request.getArchetypeGoals();
 
-        if ( StringUtils.isEmpty( postArchetypeGenerationGoals ) )
+        if ( postArchetypeGenerationGoals == null || postArchetypeGenerationGoals.isEmpty() )
         {
             postArchetypeGenerationGoals = goals;
         }
 
-        if ( StringUtils.isNotEmpty( postArchetypeGenerationGoals ) )
+        if ( postArchetypeGenerationGoals != null && !postArchetypeGenerationGoals.isEmpty() )
         {
             invokePostArchetypeGenerationGoals( postArchetypeGenerationGoals, artifactId );
         }

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/IntegrationTestMojo.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/IntegrationTestMojo.java
@@ -329,7 +329,7 @@ public class IntegrationTestMojo
             }
 
             String errors = errorWriter.toString();
-            if ( !(errors == null || errors.isEmpty()) )
+            if ( !( errors == null || errors.isEmpty() ) )
             {
                 throw new MojoExecutionException( errors );
             }

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/IntegrationTestMojo.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/IntegrationTestMojo.java
@@ -329,7 +329,7 @@ public class IntegrationTestMojo
             }
 
             String errors = errorWriter.toString();
-            if ( !StringUtils.isEmpty( errors ) )
+            if ( !(errors == null || errors.isEmpty()) )
             {
                 throw new MojoExecutionException( errors );
             }
@@ -499,7 +499,7 @@ public class IntegrationTestMojo
 
             String goals = FileUtils.fileRead( goalFile );
 
-            if ( StringUtils.isNotEmpty( goals ) )
+            if ( goals != null && !goals.isEmpty() )
             {
                 invokePostArchetypeGenerationGoals( goals.trim(), new File( basedir, request.getArtifactId() ),
                                                     goalFile );
@@ -560,17 +560,17 @@ public class IntegrationTestMojo
         
         Properties archetypePomProperties = loadProperties( archetypePomPropertiesFile );
         String groupId = archetypePomProperties.getProperty( Constants.GROUP_ID );
-        if ( StringUtils.isEmpty( groupId ) )
+        if ( groupId == null || groupId.isEmpty() )
         {
             throw new MojoExecutionException( "Property " + Constants.GROUP_ID + " not set in " + archetypePomPropertiesFile );
         }
         String artifactId = archetypePomProperties.getProperty( Constants.ARTIFACT_ID );
-        if ( StringUtils.isEmpty( artifactId ) )
+        if ( artifactId == null || artifactId.isEmpty() )
         {
             throw new MojoExecutionException( "Property " + Constants.ARTIFACT_ID + " not set in " + archetypePomPropertiesFile );
         }
         String version = archetypePomProperties.getProperty( Constants.VERSION );
-        if ( StringUtils.isEmpty( version ) )
+        if ( version == null || version.isEmpty() )
         {
             throw new MojoExecutionException( "Property " + Constants.VERSION + " not set in " + archetypePomPropertiesFile );
         }
@@ -979,7 +979,7 @@ public class IntegrationTestMojo
 
             Object value = properties.get( key );
 
-            return ( value != null ? value : this.mavenProject.getProperties().get( key ) );
+            return value != null ? value : this.mavenProject.getProperties().get( key );
 
         }
 

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/ArchetypePrompter.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/ArchetypePrompter.java
@@ -25,7 +25,6 @@ import org.codehaus.plexus.components.interactivity.InputHandler;
 import org.codehaus.plexus.components.interactivity.OutputHandler;
 import org.codehaus.plexus.components.interactivity.Prompter;
 import org.codehaus.plexus.components.interactivity.PrompterException;
-import org.codehaus.plexus.util.StringUtils;
 
 import java.io.IOException;
 import java.util.List;
@@ -61,7 +60,7 @@ public class ArchetypePrompter
 
         String line = readLine();
 
-        if ( StringUtils.isEmpty( line ) )
+        if ( line == null || line.isEmpty() )
         {
             line = defaultReply;
         }
@@ -84,7 +83,7 @@ public class ArchetypePrompter
 
             line = readLine();
 
-            if ( StringUtils.isEmpty( line ) )
+            if ( line == null || line.isEmpty() )
             {
                 line = defaultReply;
             }

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/creation/DefaultArchetypeCreationConfigurator.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/creation/DefaultArchetypeCreationConfigurator.java
@@ -144,7 +144,7 @@ public class DefaultArchetypeCreationConfigurator
                         getLogger().debug( "Asking for project's package" );
                         archetypeConfiguration.setProperty(
                                                             Constants.PACKAGE,
-                                                            archetypeCreationQueryer.getPackage( StringUtils.isEmpty( resolvedPackage ) ? archetypeConfiguration.getDefaultValue( Constants.PACKAGE )
+                                                            archetypeCreationQueryer.getPackage( (resolvedPackage == null || resolvedPackage.isEmpty()) ? archetypeConfiguration.getDefaultValue( Constants.PACKAGE )
                                                                             : resolvedPackage ) );
                     }
                 } // </editor-fold>
@@ -262,7 +262,7 @@ public class DefaultArchetypeCreationConfigurator
 
         if ( StringUtils.isEmpty( properties.getProperty( Constants.PACKAGE /*, properties.getProperty ( Constants.PACKAGE_NAME ) */ ) ) )
         {
-            if ( StringUtils.isEmpty( resolvedPackage ) )
+            if ( resolvedPackage == null || resolvedPackage.isEmpty() )
             {
                 resolvedPackage = project.getGroupId();
             }

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/creation/DefaultArchetypeCreationConfigurator.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/creation/DefaultArchetypeCreationConfigurator.java
@@ -144,7 +144,7 @@ public class DefaultArchetypeCreationConfigurator
                         getLogger().debug( "Asking for project's package" );
                         archetypeConfiguration.setProperty(
                                                             Constants.PACKAGE,
-                                                            archetypeCreationQueryer.getPackage( (resolvedPackage == null || resolvedPackage.isEmpty()) ? archetypeConfiguration.getDefaultValue( Constants.PACKAGE )
+                                                            archetypeCreationQueryer.getPackage( ( resolvedPackage == null || resolvedPackage.isEmpty() ) ? archetypeConfiguration.getDefaultValue( Constants.PACKAGE )
                                                                             : resolvedPackage ) );
                     }
                 } // </editor-fold>

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeGenerationConfigurator.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeGenerationConfigurator.java
@@ -210,7 +210,7 @@ public class DefaultArchetypeGenerationConfigurator
                         {
                             String defaultValue = archetypeConfiguration.getDefaultValue( requiredProperty );
 
-                            if ( Constants.PACKAGE.equals( requiredProperty ) && StringUtils.isEmpty( defaultValue ) )
+                            if ( Constants.PACKAGE.equals( requiredProperty ) && (defaultValue == null || defaultValue.isEmpty()) )
                             {
                                 defaultValue = archetypeConfiguration.getProperty( Constants.GROUP_ID );
                             }

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeGenerationConfigurator.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeGenerationConfigurator.java
@@ -210,7 +210,7 @@ public class DefaultArchetypeGenerationConfigurator
                         {
                             String defaultValue = archetypeConfiguration.getDefaultValue( requiredProperty );
 
-                            if ( Constants.PACKAGE.equals( requiredProperty ) && (defaultValue == null || defaultValue.isEmpty()) )
+                            if ( Constants.PACKAGE.equals( requiredProperty ) && ( defaultValue == null || defaultValue.isEmpty() ) )
                             {
                                 defaultValue = archetypeConfiguration.getProperty( Constants.GROUP_ID );
                             }

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeSelector.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeSelector.java
@@ -226,7 +226,7 @@ public class DefaultArchetypeSelector
     private void updateRepository( ArchetypeDefinition definition, Archetype archetype )
     {
         String repository = archetype.getRepository();
-        if ( StringUtils.isNotEmpty( repository ) )
+        if ( repository != null && !repository.isEmpty() )
         {
             definition.setRepository( repository );
         }


### PR DESCRIPTION
Continuation of https://issues.apache.org/jira/browse/MNG-6829

Review requested of @elharo

Use this link to re-run the recipe: https://public.moderne.io/recipes/org.openrewrite.java.migrate.apache.commons.lang.IsNotEmptyToJdk?organizationId=QXBhY2hlIE1hdmVu