### PR TITLE
Fix dead link to velocity docs

### DIFF
--- a/archetype-models/archetype-descriptor/src/main/mdo/archetype-descriptor.mdo
+++ b/archetype-models/archetype-descriptor/src/main/mdo/archetype-descriptor.mdo
@@ -142,7 +142,7 @@
           <required>false</required>
           <description><![CDATA[
             Filesets can be filtered, which means the selected files will be used as
-            <a href="http://velocity.apache.org/engine/releases/velocity-1.5/user-guide.html">Velocity templates</a>.
+            <a href="https://velocity.apache.org/engine/1.5/user-guide.html">Velocity templates</a>.
             They can be non-filtered, which means the selected files will be copied without modification.
           ]]></description>
         </field>


### PR DESCRIPTION
Is this the correct approach, and if so should I also updated the generated XSD in https://github.com/apache/maven-site, or is this done automatically?