### PR TITLE
[ARCHETYPE-64] work around warning 'Don't override file...'

### DIFF
--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/JarMojo.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/JarMojo.java
@@ -133,6 +133,10 @@ public class JarMojo extends AbstractMojo {
         archiver.setOutputFile(jarFile);
 
         archiver.setArchiver((JarArchiver) archivers.get("jar"));
+        // Workaround for ARCHETYPE-649: after archetype plugin 3.1.2, the jar file contains entries for each directory,
+        // that conflict with the filesets in "archetype-metadata.xml". So force the archiver not to create jar entries
+        // for empty dirs. The same is done later on "DefaultFileSet".
+        archiver.getArchiver().setIncludeEmptyDirs(false);
 
         // configure for Reproducible Builds based on outputTimestamp value
         archiver.configureReproducible(outputTimestamp);
@@ -141,7 +145,7 @@ public class JarMojo extends AbstractMojo {
             DefaultFileSet fs = DefaultFileSet.fileSet(archetypeDirectory)
                     .prefixed("")
                     .includeExclude(null, null)
-                    .includeEmptyDirs(true);
+                    .includeEmptyDirs(false);
             fs.setUsingDefaultExcludes(useDefaultExcludes);
             archiver.getArchiver().addFileSet(fs);
 


### PR DESCRIPTION
This pull request tries to work around a warning "Don't override file ..." or "CP Don't override file..." that appeared after switching from maven archetype plugin 3.1.2 to 3.2.1 - more details and a sample see https://issues.apache.org/jira/browse/ARCHETYPE-649

The warning seems to be caused by fileset declarations in "archetype-metadata.xml": with 3.2.1, the archetype jar file contains entries for all directories, but before there were only entries for the actual files in the zip. I could also verify this difference by analyzing the jar file with WinZip.

I could work around the warning by switching off "IncludeEmptyDirs" in two places in "JarMojo.execute".

My first thought was to pass the paths of the "archetype-metadata.xml" filesets to the second argument of "DefaultFileSet.includeExclude()", but this did not have any effect - but this might also be caused by me using wrong paths;-)

[DISCLAIMER] This is my first pull request to maven, I don't have knowledge of the internals - just trying to workaround an issue that I run into. Maybe the problem is also caused by me misusing the filesets in "archetype-metadata.xml".
So please consider this more a start of a discussion that a "I have fixed something" statement ;-). If you have better suggestions to resolve this, please point me to them.