### PR TITLE
[ARCHETYPE-676] Report warning when catalog is not parsable

### DIFF
--- a/archetype-common/src/main/java/org/apache/maven/archetype/DefaultArchetypeManager.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/DefaultArchetypeManager.java
@@ -146,6 +146,7 @@ public class DefaultArchetypeManager extends AbstractLogEnabled implements Arche
 
             return source.getArchetypeCatalog(null, null);
         } catch (ArchetypeDataSourceException e) {
+            getLogger().warn("failed to read catalog", e);
             return new ArchetypeCatalog();
         }
     }
@@ -157,6 +158,7 @@ public class DefaultArchetypeManager extends AbstractLogEnabled implements Arche
 
             return source.getArchetypeCatalog(repositorySession, null);
         } catch (ArchetypeDataSourceException e) {
+            getLogger().warn("failed to read catalog", e);
             return new ArchetypeCatalog();
         }
     }

--- a/archetype-common/src/main/java/org/apache/maven/archetype/DefaultArchetypeManager.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/DefaultArchetypeManager.java
@@ -146,7 +146,10 @@ public class DefaultArchetypeManager extends AbstractLogEnabled implements Arche
 
             return source.getArchetypeCatalog(null, null);
         } catch (ArchetypeDataSourceException e) {
-            getLogger().warn("failed to read catalog", e);
+            getLogger()
+                    .warn(
+                            "failed to read catalog: " + e.getMessage(),
+                            getLogger().isDebugEnabled() ? e : null);
             return new ArchetypeCatalog();
         }
     }
@@ -158,7 +161,10 @@ public class DefaultArchetypeManager extends AbstractLogEnabled implements Arche
 
             return source.getArchetypeCatalog(repositorySession, null);
         } catch (ArchetypeDataSourceException e) {
-            getLogger().warn("failed to read catalog", e);
+            getLogger()
+                    .warn(
+                            "failed to read catalog: " + e.getMessage(),
+                            getLogger().isDebugEnabled() ? e : null);
             return new ArchetypeCatalog();
         }
     }
@@ -171,7 +177,10 @@ public class DefaultArchetypeManager extends AbstractLogEnabled implements Arche
 
             return source.getArchetypeCatalog(repositorySession, remoteRepositories);
         } catch (ArchetypeDataSourceException e) {
-            getLogger().warn("failed to download from remote", e);
+            getLogger()
+                    .warn(
+                            "failed to download from remote" + e.getMessage(),
+                            getLogger().isDebugEnabled() ? e : null);
             return new ArchetypeCatalog();
         }
     }


### PR DESCRIPTION
Closes [ARCHETYPE-676](https://issues.apache.org/jira/browse/ARCHETYPE-676)

This way the error is at least transparant. The process continues to run, for when you select multiple catalogs.

<img width="1311" alt="image" src="https://github.com/user-attachments/assets/d2de7090-6347-4dae-b7a7-f09539b80f81">
