### PR TITLE
refactor: Replace Plexus AbstractLogEnabled with SLF4J

### DIFF
--- a/archetype-common/src/main/java/org/apache/maven/archetype/DefaultArchetypeManager.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/DefaultArchetypeManager.java
@@ -148,9 +148,7 @@ public class DefaultArchetypeManager implements ArchetypeManager {
 
             return source.getArchetypeCatalog(null, null);
         } catch (ArchetypeDataSourceException e) {
-            LOGGER.warn(
-                            "failed to read catalog: " + e.getMessage(),
-                            LOGGER.isDebugEnabled() ? e : null);
+            LOGGER.warn("failed to read catalog: " + e.getMessage(), LOGGER.isDebugEnabled() ? e : null);
             return new ArchetypeCatalog();
         }
     }
@@ -162,9 +160,7 @@ public class DefaultArchetypeManager implements ArchetypeManager {
 
             return source.getArchetypeCatalog(repositorySession, null);
         } catch (ArchetypeDataSourceException e) {
-            LOGGER.warn(
-                            "failed to read catalog: " + e.getMessage(),
-                            LOGGER.isDebugEnabled() ? e : null);
+            LOGGER.warn("failed to read catalog: " + e.getMessage(), LOGGER.isDebugEnabled() ? e : null);
             return new ArchetypeCatalog();
         }
     }
@@ -177,9 +173,7 @@ public class DefaultArchetypeManager implements ArchetypeManager {
 
             return source.getArchetypeCatalog(repositorySession, remoteRepositories);
         } catch (ArchetypeDataSourceException e) {
-            LOGGER.warn(
-                            "failed to download from remote" + e.getMessage(),
-                            LOGGER.isDebugEnabled() ? e : null);
+            LOGGER.warn("failed to download from remote" + e.getMessage(), LOGGER.isDebugEnabled() ? e : null);
             return new ArchetypeCatalog();
         }
     }

--- a/archetype-common/src/main/java/org/apache/maven/archetype/DefaultArchetypeManager.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/DefaultArchetypeManager.java
@@ -37,17 +37,19 @@ import org.apache.maven.archetype.creator.ArchetypeCreator;
 import org.apache.maven.archetype.generator.ArchetypeGenerator;
 import org.apache.maven.archetype.source.ArchetypeDataSource;
 import org.apache.maven.archetype.source.ArchetypeDataSourceException;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.IOUtil;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Jason van Zyl
  */
 @Named
 @Singleton
-public class DefaultArchetypeManager extends AbstractLogEnabled implements ArchetypeManager {
+public class DefaultArchetypeManager implements ArchetypeManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArchetypeManager.class);
 
     @Inject
     @Named("fileset")
@@ -92,7 +94,7 @@ public class DefaultArchetypeManager extends AbstractLogEnabled implements Arche
         }
 
         if (!archive.exists() && !archive.createNewFile()) {
-            getLogger().warn("Could not create new file \"" + archive.getPath() + "\" or the file already exists.");
+            LOGGER.warn("Could not create new file \"" + archive.getPath() + "\" or the file already exists.");
         }
 
         try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(archive.toPath()))) {
@@ -146,10 +148,9 @@ public class DefaultArchetypeManager extends AbstractLogEnabled implements Arche
 
             return source.getArchetypeCatalog(null, null);
         } catch (ArchetypeDataSourceException e) {
-            getLogger()
-                    .warn(
+            LOGGER.warn(
                             "failed to read catalog: " + e.getMessage(),
-                            getLogger().isDebugEnabled() ? e : null);
+                            LOGGER.isDebugEnabled() ? e : null);
             return new ArchetypeCatalog();
         }
     }
@@ -161,10 +162,9 @@ public class DefaultArchetypeManager extends AbstractLogEnabled implements Arche
 
             return source.getArchetypeCatalog(repositorySession, null);
         } catch (ArchetypeDataSourceException e) {
-            getLogger()
-                    .warn(
+            LOGGER.warn(
                             "failed to read catalog: " + e.getMessage(),
-                            getLogger().isDebugEnabled() ? e : null);
+                            LOGGER.isDebugEnabled() ? e : null);
             return new ArchetypeCatalog();
         }
     }
@@ -177,10 +177,9 @@ public class DefaultArchetypeManager extends AbstractLogEnabled implements Arche
 
             return source.getArchetypeCatalog(repositorySession, remoteRepositories);
         } catch (ArchetypeDataSourceException e) {
-            getLogger()
-                    .warn(
+            LOGGER.warn(
                             "failed to download from remote" + e.getMessage(),
-                            getLogger().isDebugEnabled() ? e : null);
+                            LOGGER.isDebugEnabled() ? e : null);
             return new ArchetypeCatalog();
         }
     }
@@ -192,7 +191,7 @@ public class DefaultArchetypeManager extends AbstractLogEnabled implements Arche
 
             return source.updateCatalog(repositorySystemSession, archetype);
         } catch (ArchetypeDataSourceException e) {
-            getLogger().warn("failed to update catalog", e);
+            LOGGER.warn("failed to update catalog", e);
         }
         return null;
     }

--- a/archetype-common/src/main/java/org/apache/maven/archetype/common/DefaultArchetypeArtifactManager.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/common/DefaultArchetypeArtifactManager.java
@@ -47,14 +47,16 @@ import org.apache.maven.archetype.metadata.ArchetypeDescriptor;
 import org.apache.maven.archetype.metadata.io.xpp3.ArchetypeDescriptorXpp3Reader;
 import org.apache.maven.archetype.old.descriptor.ArchetypeDescriptorBuilder;
 import org.apache.maven.model.Model;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Named
 @Singleton
-public class DefaultArchetypeArtifactManager extends AbstractLogEnabled implements ArchetypeArtifactManager {
+public class DefaultArchetypeArtifactManager implements ArchetypeArtifactManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArchetypeArtifactManager.class);
     @Inject
     private Downloader downloader;
 
@@ -138,24 +140,24 @@ public class DefaultArchetypeArtifactManager extends AbstractLogEnabled implemen
 
     @Override
     public boolean isFileSetArchetype(File archetypeFile) {
-        getLogger().debug("checking fileset archetype status on " + archetypeFile);
+        LOGGER.debug("checking fileset archetype status on " + archetypeFile);
 
         try (ZipFile zipFile = getArchetypeZipFile(archetypeFile)) {
             return isFileSetArchetype(zipFile);
         } catch (IOException | UnknownArchetype e) {
-            getLogger().debug(e.toString());
+            LOGGER.debug(e.toString());
             return false;
         }
     }
 
     @Override
     public boolean isOldArchetype(File archetypeFile) {
-        getLogger().debug("checking old archetype status on " + archetypeFile);
+        LOGGER.debug("checking old archetype status on " + archetypeFile);
 
         try (ZipFile zipFile = getArchetypeZipFile(archetypeFile)) {
             return isOldArchetype(zipFile);
         } catch (IOException | UnknownArchetype e) {
-            getLogger().debug(e.toString());
+            LOGGER.debug(e.toString());
             return false;
         }
     }
@@ -181,8 +183,7 @@ public class DefaultArchetypeArtifactManager extends AbstractLogEnabled implemen
 
             return archetype.exists();
         } catch (DownloadException e) {
-            getLogger()
-                    .debug(
+            LOGGER.debug(
                             "Archetype " + archetypeGroupId + ":" + archetypeArtifactId + ":" + archetypeVersion
                                     + " doesn't exist",
                             e);
@@ -211,7 +212,7 @@ public class DefaultArchetypeArtifactManager extends AbstractLogEnabled implemen
 
     @Override
     public List<String> getFilesetArchetypeResources(File archetypeFile) throws UnknownArchetype {
-        getLogger().debug("getFilesetArchetypeResources( \"" + archetypeFile.getAbsolutePath() + "\" )");
+        LOGGER.debug("getFilesetArchetypeResources( \"" + archetypeFile.getAbsolutePath() + "\" )");
         List<String> archetypeResources = new ArrayList<>();
 
         try (ZipFile zipFile = getArchetypeZipFile(archetypeFile)) {
@@ -222,11 +223,11 @@ public class DefaultArchetypeArtifactManager extends AbstractLogEnabled implemen
                 if (entry.getName().startsWith(Constants.ARCHETYPE_RESOURCES)) {
                     // not supposed to be file.separator
                     String resource = entry.getName().substring(Constants.ARCHETYPE_RESOURCES.length() + 1);
-                    getLogger().debug("  - found resource (" + Constants.ARCHETYPE_RESOURCES + "/)" + resource);
+                    LOGGER.debug("  - found resource (" + Constants.ARCHETYPE_RESOURCES + "/)" + resource);
                     // TODO:FIXME
                     archetypeResources.add(resource);
                 } else {
-                    getLogger().debug("  - ignored resource " + entry.getName());
+                    LOGGER.debug("  - ignored resource " + entry.getName());
                 }
             }
             return archetypeResources;
@@ -249,12 +250,12 @@ public class DefaultArchetypeArtifactManager extends AbstractLogEnabled implemen
         String key = archetypeGroupId + ":" + archetypeArtifactId + ":" + archetypeVersion;
 
         if (archetypeCache.containsKey(key)) {
-            getLogger().debug("Found archetype " + key + " in cache: " + archetypeCache.get(key));
+            LOGGER.debug("Found archetype " + key + " in cache: " + archetypeCache.get(key));
 
             return archetypeCache.get(key);
         }
 
-        getLogger().debug("Not found archetype " + key + " in cache");
+        LOGGER.debug("Not found archetype " + key + " in cache");
         return null;
     }
 
@@ -335,15 +336,15 @@ public class DefaultArchetypeArtifactManager extends AbstractLogEnabled implemen
     }
 
     private ZipEntry searchEntry(ZipFile zipFile, String searchString) {
-        getLogger().debug("Searching for " + searchString + " inside " + zipFile.getName());
+        LOGGER.debug("Searching for " + searchString + " inside " + zipFile.getName());
 
         Enumeration<? extends ZipEntry> enu = zipFile.entries();
         while (enu.hasMoreElements()) {
             ZipEntry entryfound = enu.nextElement();
-            getLogger().debug("  - " + entryfound.getName());
+            LOGGER.debug("  - " + entryfound.getName());
 
             if (searchString.equals(entryfound.getName())) {
-                getLogger().debug("Entry found");
+                LOGGER.debug("Entry found");
                 return entryfound;
             }
         }

--- a/archetype-common/src/main/java/org/apache/maven/archetype/common/DefaultArchetypeArtifactManager.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/common/DefaultArchetypeArtifactManager.java
@@ -57,6 +57,7 @@ import org.slf4j.LoggerFactory;
 @Singleton
 public class DefaultArchetypeArtifactManager implements ArchetypeArtifactManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArchetypeArtifactManager.class);
+
     @Inject
     private Downloader downloader;
 
@@ -184,9 +185,9 @@ public class DefaultArchetypeArtifactManager implements ArchetypeArtifactManager
             return archetype.exists();
         } catch (DownloadException e) {
             LOGGER.debug(
-                            "Archetype " + archetypeGroupId + ":" + archetypeArtifactId + ":" + archetypeVersion
-                                    + " doesn't exist",
-                            e);
+                    "Archetype " + archetypeGroupId + ":" + archetypeArtifactId + ":" + archetypeVersion
+                            + " doesn't exist",
+                    e);
             return false;
         }
     }

--- a/archetype-common/src/main/java/org/apache/maven/archetype/common/DefaultArchetypeFilesResolver.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/common/DefaultArchetypeFilesResolver.java
@@ -31,13 +31,16 @@ import java.util.Set;
 import org.apache.maven.archetype.common.util.ListScanner;
 import org.apache.maven.archetype.common.util.PathUtils;
 import org.apache.maven.archetype.metadata.FileSet;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Named
 @Singleton
-public class DefaultArchetypeFilesResolver extends AbstractLogEnabled implements ArchetypeFilesResolver {
+public class DefaultArchetypeFilesResolver implements ArchetypeFilesResolver {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArchetypeFilesResolver.class);
+
     @Override
     public List<String> getFilesWithExtension(List<String> files, String extension) {
         ListScanner scanner = new ListScanner();
@@ -58,7 +61,7 @@ public class DefaultArchetypeFilesResolver extends AbstractLogEnabled implements
         scanner.setExcludes("");
 
         List<String> result = scanner.scan(files);
-        getLogger().debug("Scanned " + result.size() + " filtered files in " + files.size() + " files");
+        LOGGER.debug("Scanned " + result.size() + " filtered files in " + files.size() + " files");
 
         return result;
     }
@@ -91,8 +94,7 @@ public class DefaultArchetypeFilesResolver extends AbstractLogEnabled implements
         scanner.setExcludes(languages);
 
         List<String> result = scanner.scan(files);
-        getLogger()
-                .debug("Scanned " + result.size() + " other resources in " + files.size() + " files at level " + level);
+        LOGGER.debug("Scanned " + result.size() + " other resources in " + files.size() + " files at level " + level);
 
         return result;
     }
@@ -119,8 +121,7 @@ public class DefaultArchetypeFilesResolver extends AbstractLogEnabled implements
         scanner.setExcludes(languages);
 
         List<String> result = scanner.scan(files);
-        getLogger()
-                .debug("Scanned " + result.size() + " other resources in " + files.size() + " files at level " + level);
+        LOGGER.debug("Scanned " + result.size() + " other resources in " + files.size() + " files at level " + level);
 
         return result;
     }
@@ -144,8 +145,7 @@ public class DefaultArchetypeFilesResolver extends AbstractLogEnabled implements
         scanner.setIncludes(includes.toString());
 
         List<String> result = scanner.scan(files);
-        getLogger()
-                .debug("Scanned " + result.size() + " other sources in " + files.size() + " files at level " + level);
+        LOGGER.debug("Scanned " + result.size() + " other sources in " + files.size() + " files at level " + level);
 
         return result;
     }
@@ -159,7 +159,7 @@ public class DefaultArchetypeFilesResolver extends AbstractLogEnabled implements
         scanner.setExcludes(languages);
 
         List<String> result = scanner.scan(files);
-        getLogger().debug("Scanned " + result.size() + " resources in " + files.size() + " files");
+        LOGGER.debug("Scanned " + result.size() + " resources in " + files.size() + " files");
 
         return result;
     }
@@ -173,7 +173,7 @@ public class DefaultArchetypeFilesResolver extends AbstractLogEnabled implements
         scanner.setExcludes(languages);
 
         List<String> result = scanner.scan(files);
-        getLogger().debug("Scanned " + result.size() + " test resources in " + files.size() + " files");
+        LOGGER.debug("Scanned " + result.size() + " test resources in " + files.size() + " files");
 
         return result;
     }
@@ -187,7 +187,7 @@ public class DefaultArchetypeFilesResolver extends AbstractLogEnabled implements
         scanner.setExcludes(languages);
 
         List<String> result = scanner.scan(files);
-        getLogger().debug("Scanned " + result.size() + " site resources in " + files.size() + " files");
+        LOGGER.debug("Scanned " + result.size() + " site resources in " + files.size() + " files");
 
         return result;
     }
@@ -200,7 +200,7 @@ public class DefaultArchetypeFilesResolver extends AbstractLogEnabled implements
         scanner.setIncludes(languages);
 
         List<String> result = scanner.scan(files);
-        getLogger().debug("Scanned " + result.size() + " sources in " + files.size() + " files");
+        LOGGER.debug("Scanned " + result.size() + " sources in " + files.size() + " files");
 
         return result;
     }
@@ -213,7 +213,7 @@ public class DefaultArchetypeFilesResolver extends AbstractLogEnabled implements
         scanner.setIncludes(languages);
 
         List<String> result = scanner.scan(files);
-        getLogger().debug("Scanned " + result.size() + " test sources in " + files.size() + " files");
+        LOGGER.debug("Scanned " + result.size() + " test sources in " + files.size() + " files");
 
         return result;
     }
@@ -226,13 +226,13 @@ public class DefaultArchetypeFilesResolver extends AbstractLogEnabled implements
                 packagedFiles.add(file.substring(packageName.length() + 1));
             }
         }
-        getLogger().debug("Scanned " + packagedFiles.size() + " packaged files in " + files.size() + " files");
+        LOGGER.debug("Scanned " + packagedFiles.size() + " packaged files in " + files.size() + " files");
         return packagedFiles;
     }
 
     @Override
     public String resolvePackage(File basedir, List<String> languages) throws IOException {
-        getLogger().debug("Resolving package in " + basedir + " using languages " + languages);
+        LOGGER.debug("Resolving package in " + basedir + " using languages " + languages);
 
         List<String> files = resolveFiles(basedir, languages);
 
@@ -247,7 +247,7 @@ public class DefaultArchetypeFilesResolver extends AbstractLogEnabled implements
                 unpackagedFiles.add(file);
             }
         }
-        getLogger().debug("Scanned " + unpackagedFiles.size() + " unpackaged files in " + files.size() + " files");
+        LOGGER.debug("Scanned " + unpackagedFiles.size() + " unpackaged files in " + files.size() + " files");
         return unpackagedFiles;
     }
 
@@ -283,7 +283,7 @@ public class DefaultArchetypeFilesResolver extends AbstractLogEnabled implements
 
         List<File> absoluteFiles = FileUtils.getFiles(basedir, StringUtils.join(languagesPathesArray, ","), excludes);
 
-        getLogger().debug("Found " + absoluteFiles.size() + " potential archetype files");
+        LOGGER.debug("Found " + absoluteFiles.size() + " potential archetype files");
 
         List<String> files = new ArrayList<>(absoluteFiles.size());
 
@@ -303,7 +303,7 @@ public class DefaultArchetypeFilesResolver extends AbstractLogEnabled implements
             }
         }
 
-        getLogger().debug("Found " + files.size() + " archetype files for package resolution ");
+        LOGGER.debug("Found " + files.size() + " archetype files for package resolution ");
 
         return files;
     }
@@ -325,7 +325,7 @@ public class DefaultArchetypeFilesResolver extends AbstractLogEnabled implements
             }
         }
 
-        getLogger().debug("Package resolved to " + packageName);
+        LOGGER.debug("Package resolved to " + packageName);
 
         return packageName;
     }

--- a/archetype-common/src/main/java/org/apache/maven/archetype/common/DefaultPomManager.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/common/DefaultPomManager.java
@@ -54,7 +54,6 @@ import org.apache.maven.model.ReportPlugin;
 import org.apache.maven.model.Reporting;
 import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.XmlStreamReader;
@@ -63,11 +62,15 @@ import org.codehaus.plexus.util.xml.Xpp3DomUtils;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.jdom2.JDOMException;
 import org.jdom2.input.SAXBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
 @Named
 @Singleton
-public class DefaultPomManager extends AbstractLogEnabled implements PomManager {
+public class DefaultPomManager implements PomManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultPomManager.class);
+
     @Override
     public void addModule(File pom, String artifactId)
             throws IOException, ParserConfigurationException, TransformerException, SAXException, InvalidPackaging,
@@ -83,7 +86,7 @@ public class DefaultPomManager extends AbstractLogEnabled implements PomManager 
     public void addParent(File pom, File parentPom) throws IOException, XmlPullParserException {
         Model generatedModel = readPom(pom);
         if (null != generatedModel.getParent()) {
-            getLogger().info("Parent element not overwritten in " + pom);
+            LOGGER.info("Parent element not overwritten in " + pom);
             return;
         }
 
@@ -212,7 +215,7 @@ public class DefaultPomManager extends AbstractLogEnabled implements PomManager 
         }
 
         if (!pomFile.exists() && !pomFile.createNewFile()) {
-            getLogger().warn("Could not create new file \"" + pomFile.getPath() + "\" or the file already exists.");
+            LOGGER.warn("Could not create new file \"" + pomFile.getPath() + "\" or the file already exists.");
         }
 
         try (Writer outputStreamWriter = new OutputStreamWriter(new FileOutputStream(pomFile), fileEncoding)) {
@@ -223,7 +226,7 @@ public class DefaultPomManager extends AbstractLogEnabled implements PomManager 
             Format form = Format.getRawFormat().setEncoding(fileEncoding).setLineSeparator(ls);
             writer.write(model, doc, outputStreamWriter, form);
         } catch (FileNotFoundException e) {
-            getLogger().debug("Creating pom file " + pomFile);
+            LOGGER.debug("Creating pom file " + pomFile);
 
             try (Writer pomWriter = new OutputStreamWriter(Files.newOutputStream(pomFile.toPath()), fileEncoding)) {
                 MavenXpp3Writer writer = new MavenXpp3Writer();
@@ -271,7 +274,7 @@ public class DefaultPomManager extends AbstractLogEnabled implements PomManager 
                 if (!modelProfileIdMap.containsKey(generatedProfileId)) {
                     model.addProfile(generatedProfile);
                 } else {
-                    getLogger().warn("Try to merge profiles with id " + generatedProfileId);
+                    LOGGER.warn("Try to merge profiles with id " + generatedProfileId);
                     mergeModelBase(modelProfileIdMap.get(generatedProfileId), generatedProfile);
                     mergeProfileBuild(modelProfileIdMap.get(generatedProfileId), generatedProfile);
                 }
@@ -299,7 +302,7 @@ public class DefaultPomManager extends AbstractLogEnabled implements PomManager 
             if (!dependenciesByIds.containsKey(generatedDependencyId)) {
                 model.addDependency(generatedDependenciesByIds.get(generatedDependencyId));
             } else {
-                getLogger().warn("Can not override property: " + generatedDependencyId);
+                LOGGER.warn("Can not override property: " + generatedDependencyId);
             }
 
             // TODO: maybe warn, if a property key gets overridden?
@@ -324,7 +327,7 @@ public class DefaultPomManager extends AbstractLogEnabled implements PomManager 
                 if (!reportPluginsByIds.containsKey(generatedReportPluginsId)) {
                     model.getReporting().addPlugin(generatedReportPluginsByIds.get(generatedReportPluginsId));
                 } else {
-                    getLogger().warn("Can not override report: " + generatedReportPluginsId);
+                    LOGGER.warn("Can not override report: " + generatedReportPluginsId);
                 }
             }
         }
@@ -341,7 +344,7 @@ public class DefaultPomManager extends AbstractLogEnabled implements PomManager 
             if (!pluginsByIds.containsKey(generatedPluginsId)) {
                 modelBuild.addPlugin(generatedPlugin);
             } else {
-                getLogger().info("Try to merge plugin configuration of plugins with id: " + generatedPluginsId);
+                LOGGER.info("Try to merge plugin configuration of plugins with id: " + generatedPluginsId);
                 Plugin modelPlugin = pluginsByIds.get(generatedPluginsId);
 
                 modelPlugin.setConfiguration(Xpp3DomUtils.mergeXpp3Dom(

--- a/archetype-common/src/main/java/org/apache/maven/archetype/common/util/FileCharsetDetector.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/common/util/FileCharsetDetector.java
@@ -27,12 +27,14 @@ import java.util.Locale;
 
 import com.ibm.icu.text.CharsetDetector;
 import com.ibm.icu.text.CharsetMatch;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author rafale
  */
-public class FileCharsetDetector extends AbstractLogEnabled {
+public class FileCharsetDetector {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FileCharsetDetector.class);
     private final String charset;
 
     public FileCharsetDetector(File detectedFile) throws IOException {

--- a/archetype-common/src/main/java/org/apache/maven/archetype/creator/FilesetArchetypeCreator.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/creator/FilesetArchetypeCreator.java
@@ -272,7 +272,7 @@ public class FilesetArchetypeCreator implements ArchetypeCreator {
 
             if (archetypeIntegrationTestInputFolder.exists()) {
                 LOGGER.info("Copying: " + archetypeIntegrationTestInputFolder.getAbsolutePath() + " into "
-                                + archetypeIntegrationTestOutputFolder.getAbsolutePath());
+                        + archetypeIntegrationTestOutputFolder.getAbsolutePath());
 
                 FileUtils.copyDirectoryStructure(
                         archetypeIntegrationTestInputFolder, archetypeIntegrationTestOutputFolder);
@@ -322,7 +322,7 @@ public class FilesetArchetypeCreator implements ArchetypeCreator {
         File archetypePropertiesFile = new File(basicItDirectory, "archetype.properties");
         if (!archetypePropertiesFile.exists() && !archetypePropertiesFile.createNewFile()) {
             LOGGER.warn("Could not create new file \"" + archetypePropertiesFile.getPath()
-                            + "\" or the file already exists.");
+                    + "\" or the file already exists.");
         }
 
         try (InputStream in = FilesetArchetypeCreator.class.getResourceAsStream("archetype.properties");
@@ -473,7 +473,7 @@ public class FilesetArchetypeCreator implements ArchetypeCreator {
             archetypeDescriptor.addRequiredProperty(requiredProperty);
 
             LOGGER.debug("Adding requiredProperty " + propertyKey + "=" + requiredProperties.getProperty(propertyKey)
-                            + " to archetype's descriptor");
+                    + " to archetype's descriptor");
         }
     }
 
@@ -885,8 +885,8 @@ public class FilesetArchetypeCreator implements ArchetypeCreator {
                 String property = (String) properties.next();
 
                 if (initialcontent.indexOf("${" + property + "}") > 0) {
-                    LOGGER.warn("Archetype uses ${" + property + "} for internal processing, but file "
-                                    + initialPomFile + " contains this property already");
+                    LOGGER.warn("Archetype uses ${" + property + "} for internal processing, but file " + initialPomFile
+                            + " contains this property already");
                 }
             }
         }
@@ -924,7 +924,7 @@ public class FilesetArchetypeCreator implements ArchetypeCreator {
 
         if (!files.isEmpty()) {
             LOGGER.debug("Creating filesets" + (packaged ? (" packaged (" + packageName + ")") : "")
-                            + (filtered ? " filtered" : "") + " at level " + level);
+                    + (filtered ? " filtered" : "") + " at level " + level);
             if (level == 0) {
                 List<String> includes = new ArrayList<>(files);
                 List<String> excludes = new ArrayList<>();
@@ -1128,7 +1128,7 @@ public class FilesetArchetypeCreator implements ArchetypeCreator {
 
                 if (initialcontent.indexOf("${" + property + "}") > 0) {
                     LOGGER.warn("OldArchetype uses ${" + property + "} for internal processing, but file "
-                                    + initialPomFile + " contains this property already");
+                            + initialPomFile + " contains this property already");
                 }
             }
         }
@@ -1266,7 +1266,7 @@ public class FilesetArchetypeCreator implements ArchetypeCreator {
 
                 if (initialcontent.indexOf("${" + property + "}") > 0) {
                     LOGGER.warn("Archetype uses ${" + property + "} for internal processing, but file " + inputFile
-                                    + " contains this property already");
+                            + " contains this property already");
                 }
             }
 
@@ -1343,8 +1343,8 @@ public class FilesetArchetypeCreator implements ArchetypeCreator {
             List<String> filtereds,
             String defaultEncoding) {
         List<FileSet> resolvedFileSets = new ArrayList<>();
-        LOGGER.debug("Resolving filesets with package=" + packageName + ", languages=" + languages
-                        + " and extentions=" + filtereds);
+        LOGGER.debug("Resolving filesets with package=" + packageName + ", languages=" + languages + " and extentions="
+                + filtereds);
 
         List<String> files = new ArrayList<>(fileNames);
 

--- a/archetype-common/src/main/java/org/apache/maven/archetype/generator/DefaultArchetypeGenerator.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/generator/DefaultArchetypeGenerator.java
@@ -36,16 +36,18 @@ import org.apache.maven.archetype.exception.ArchetypeNotDefined;
 import org.apache.maven.archetype.exception.InvalidPackaging;
 import org.apache.maven.archetype.exception.UnknownArchetype;
 import org.apache.maven.archetype.old.OldArchetype;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.StringUtils;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Named
 @Singleton
-public class DefaultArchetypeGenerator extends AbstractLogEnabled implements ArchetypeGenerator {
+public class DefaultArchetypeGenerator implements ArchetypeGenerator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArchetypeGenerator.class);
 
     @Inject
     private ArchetypeArtifactManager archetypeArtifactManager;

--- a/archetype-common/src/main/java/org/apache/maven/archetype/generator/DefaultFilesetArchetypeGenerator.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/generator/DefaultFilesetArchetypeGenerator.java
@@ -76,6 +76,7 @@ import org.xml.sax.SAXException;
 @Singleton
 public class DefaultFilesetArchetypeGenerator implements FilesetArchetypeGenerator {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultFilesetArchetypeGenerator.class);
+
     @Inject
     private ArchetypeArtifactManager archetypeArtifactManager;
 
@@ -362,13 +363,13 @@ public class DefaultFilesetArchetypeGenerator implements FilesetArchetypeGenerat
             if (contextPropertyValue != null && !contextPropertyValue.trim().isEmpty()) {
                 if (LOGGER.isDebugEnabled()) {
                     LOGGER.debug("Replacing property '" + propertyToken + "' in file path '" + filePath
-                                    + "' with value '" + contextPropertyValue + "'.");
+                            + "' with value '" + contextPropertyValue + "'.");
                 }
                 matcher.appendReplacement(interpolatedResult, contextPropertyValue);
             } else {
                 // Need to skip the undefined property
                 LOGGER.warn("Property '" + propertyToken + "' was not specified, so the token in '" + filePath
-                                + "' is not being replaced.");
+                        + "' is not being replaced.");
             }
         }
 
@@ -412,7 +413,7 @@ public class DefaultFilesetArchetypeGenerator implements FilesetArchetypeGenerat
             LOGGER.info("----------------------------------------------------------------------------");
 
             LOGGER.info("Using following parameters for creating project from Archetype: "
-                            + request.getArchetypeArtifactId() + ":" + request.getArchetypeVersion());
+                    + request.getArchetypeArtifactId() + ":" + request.getArchetypeVersion());
 
             LOGGER.info("----------------------------------------------------------------------------");
             LOGGER.info("Parameter: " + Constants.GROUP_ID + ", Value: " + request.getGroupId());
@@ -788,7 +789,7 @@ public class DefaultFilesetArchetypeGenerator implements FilesetArchetypeGenerat
 
             if (fileSet.isFiltered()) {
                 LOGGER.debug("    Processing fileset " + fileSet + " -> " + fileSetResources.size() + ":\n      "
-                                + fileSetResources);
+                        + fileSetResources);
 
                 int processed = processFileSet(
                         fileSet.getDirectory(),
@@ -804,7 +805,7 @@ public class DefaultFilesetArchetypeGenerator implements FilesetArchetypeGenerat
                 LOGGER.debug("    Processed " + processed + " files.");
             } else {
                 LOGGER.debug("    Copying fileset " + fileSet + " -> " + fileSetResources.size() + ":\n      "
-                                + fileSetResources);
+                        + fileSetResources);
 
                 int copied = copyFiles(
                         fileSet.getDirectory(),

--- a/archetype-common/src/main/java/org/apache/maven/archetype/old/DefaultOldArchetype.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/old/DefaultOldArchetype.java
@@ -57,7 +57,6 @@ import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
 import org.apache.maven.model.io.xpp3.MavenXpp3Writer;
 import org.apache.velocity.VelocityContext;
 import org.apache.velocity.context.Context;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.FileUtils;
 import org.codehaus.plexus.util.IOUtil;
 import org.codehaus.plexus.util.StringUtils;
@@ -65,6 +64,8 @@ import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.codehaus.plexus.util.xml.XmlStreamWriter;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
 import org.codehaus.plexus.velocity.VelocityComponent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
 /**
@@ -73,7 +74,8 @@ import org.xml.sax.SAXException;
  */
 @Named
 @Singleton
-public class DefaultOldArchetype extends AbstractLogEnabled implements OldArchetype {
+public class DefaultOldArchetype implements OldArchetype {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultOldArchetype.class);
     private static final String DEFAULT_TEST_RESOURCE_DIR = "/src/test/resources";
 
     private static final String DEFAULT_TEST_SOURCE_DIR = "/src/test/java";
@@ -139,21 +141,20 @@ public class DefaultOldArchetype extends AbstractLogEnabled implements OldArchet
         // ---------------------------------------------------------------------
         // Get Logger and display all parameters used
         // ---------------------------------------------------------------------
-        if (getLogger().isInfoEnabled()) {
-            getLogger().info("----------------------------------------------------------------------------");
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("----------------------------------------------------------------------------");
 
-            getLogger()
-                    .info("Using following parameters for creating project from Old (1.x) Archetype: "
+            LOGGER.info("Using following parameters for creating project from Old (1.x) Archetype: "
                             + request.getArchetypeArtifactId() + ":" + request.getArchetypeVersion());
 
-            getLogger().info("----------------------------------------------------------------------------");
+            LOGGER.info("----------------------------------------------------------------------------");
 
             for (Map.Entry<String, String> entry : parameters.entrySet()) {
                 String parameterName = entry.getKey();
 
                 String parameterValue = entry.getValue();
 
-                getLogger().info("Parameter: " + parameterName + ", Value: " + parameterValue);
+                LOGGER.info("Parameter: " + parameterName + ", Value: " + parameterValue);
             }
         }
 
@@ -323,8 +324,8 @@ public class DefaultOldArchetype extends AbstractLogEnabled implements OldArchet
         // ----------------------------------------------------------------------
         // Log message on OldArchetype creation
         // ----------------------------------------------------------------------
-        if (getLogger().isInfoEnabled()) {
-            getLogger().info("project created from Old (1.x) Archetype in dir: " + outputDirectory);
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("project created from Old (1.x) Archetype in dir: " + outputDirectory);
         }
     }
 
@@ -411,16 +412,15 @@ public class DefaultOldArchetype extends AbstractLogEnabled implements OldArchet
 
         boolean foundBuildElement = build != null;
 
-        if (getLogger().isDebugEnabled()) {
-            getLogger()
-                    .debug(
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug(
                             "********************* Debug info for resources created from generated Model ***********************");
-            getLogger().debug("Was build element found in generated POM?: " + foundBuildElement);
+            LOGGER.debug("Was build element found in generated POM?: " + foundBuildElement);
         }
 
         // create source directory if specified in POM
         if (foundBuildElement && null != build.getSourceDirectory()) {
-            getLogger().debug("Overriding default source directory ");
+            LOGGER.debug("Overriding default source directory ");
 
             overrideSrcDir = true;
 
@@ -433,7 +433,7 @@ public class DefaultOldArchetype extends AbstractLogEnabled implements OldArchet
 
         // create script source directory if specified in POM
         if (foundBuildElement && null != build.getScriptSourceDirectory()) {
-            getLogger().debug("Overriding default script source directory ");
+            LOGGER.debug("Overriding default script source directory ");
 
             String scriptSourceDirectory = build.getScriptSourceDirectory();
 
@@ -444,7 +444,7 @@ public class DefaultOldArchetype extends AbstractLogEnabled implements OldArchet
 
         // create resource director(y/ies) if specified in POM
         if (foundBuildElement && !build.getResources().isEmpty()) {
-            getLogger().debug("Overriding default resource directory ");
+            LOGGER.debug("Overriding default resource directory ");
 
             overrideResourceDir = true;
 
@@ -462,7 +462,7 @@ public class DefaultOldArchetype extends AbstractLogEnabled implements OldArchet
         }
         // create test source directory if specified in POM
         if (foundBuildElement && null != build.getTestSourceDirectory()) {
-            getLogger().debug("Overriding default test directory ");
+            LOGGER.debug("Overriding default test directory ");
 
             overrideTestSrcDir = true;
 
@@ -475,7 +475,7 @@ public class DefaultOldArchetype extends AbstractLogEnabled implements OldArchet
 
         // create test resource directory if specified in POM
         if (foundBuildElement && !build.getTestResources().isEmpty()) {
-            getLogger().debug("Overriding default test resource directory ");
+            LOGGER.debug("Overriding default test resource directory ");
 
             overrideTestResourceDir = true;
 
@@ -492,8 +492,7 @@ public class DefaultOldArchetype extends AbstractLogEnabled implements OldArchet
             }
         }
 
-        getLogger()
-                .debug(
+        LOGGER.debug(
                         "********************* End of debug info from resources from generated POM ***********************");
 
         // ----------------------------------------------------------------------
@@ -690,7 +689,7 @@ public class DefaultOldArchetype extends AbstractLogEnabled implements OldArchet
         }
 
         if (!f.exists() && !f.createNewFile()) {
-            getLogger().warn("Could not create new file \"" + f.getPath() + "\" or the file already exists.");
+            LOGGER.warn("Could not create new file \"" + f.getPath() + "\" or the file already exists.");
         }
 
         if (descriptor.isFiltered()) {

--- a/archetype-common/src/main/java/org/apache/maven/archetype/old/DefaultOldArchetype.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/old/DefaultOldArchetype.java
@@ -145,7 +145,7 @@ public class DefaultOldArchetype implements OldArchetype {
             LOGGER.info("----------------------------------------------------------------------------");
 
             LOGGER.info("Using following parameters for creating project from Old (1.x) Archetype: "
-                            + request.getArchetypeArtifactId() + ":" + request.getArchetypeVersion());
+                    + request.getArchetypeArtifactId() + ":" + request.getArchetypeVersion());
 
             LOGGER.info("----------------------------------------------------------------------------");
 
@@ -414,7 +414,7 @@ public class DefaultOldArchetype implements OldArchetype {
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debug(
-                            "********************* Debug info for resources created from generated Model ***********************");
+                    "********************* Debug info for resources created from generated Model ***********************");
             LOGGER.debug("Was build element found in generated POM?: " + foundBuildElement);
         }
 
@@ -493,7 +493,7 @@ public class DefaultOldArchetype implements OldArchetype {
         }
 
         LOGGER.debug(
-                        "********************* End of debug info from resources from generated POM ***********************");
+                "********************* End of debug info from resources from generated POM ***********************");
 
         // ----------------------------------------------------------------------
         // Main

--- a/archetype-common/src/main/java/org/apache/maven/archetype/repositorycrawler/DefaultRepositoryCrawler.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/repositorycrawler/DefaultRepositoryCrawler.java
@@ -34,24 +34,26 @@ import org.apache.maven.archetype.catalog.io.xpp3.ArchetypeCatalogXpp3Writer;
 import org.apache.maven.archetype.common.ArchetypeArtifactManager;
 import org.apache.maven.archetype.exception.UnknownArchetype;
 import org.apache.maven.model.Model;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.xml.XmlStreamWriter;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author            rafale
  */
 @Named
 @Singleton
-public class DefaultRepositoryCrawler extends AbstractLogEnabled implements RepositoryCrawler {
+public class DefaultRepositoryCrawler implements RepositoryCrawler {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRepositoryCrawler.class);
     @Inject
     private ArchetypeArtifactManager archetypeArtifactManager;
 
     @Override
     public ArchetypeCatalog crawl(File repository) {
         if (!repository.isDirectory()) {
-            getLogger().warn("File is not a directory");
+            LOGGER.warn("File is not a directory");
             return null;
         }
 
@@ -62,7 +64,7 @@ public class DefaultRepositoryCrawler extends AbstractLogEnabled implements Repo
 
         while (jars.hasNext()) {
             File jar = jars.next();
-            getLogger().info("Scanning " + jar);
+            LOGGER.info("Scanning " + jar);
             if (archetypeArtifactManager.isFileSetArchetype(jar) || archetypeArtifactManager.isOldArchetype(jar)) {
                 try {
                     Archetype archetype = new Archetype();
@@ -90,7 +92,7 @@ public class DefaultRepositoryCrawler extends AbstractLogEnabled implements Repo
                         } else {
                             archetype.setVersion(pom.getParent().getVersion());
                         }
-                        getLogger().info("\tArchetype " + archetype + " found in pom");
+                        LOGGER.info("\tArchetype " + archetype + " found in pom");
                     } else {
                         String version = jar.getParentFile().getName();
 
@@ -111,7 +113,7 @@ public class DefaultRepositoryCrawler extends AbstractLogEnabled implements Repo
                         archetype.setArtifactId(artifactId);
                         archetype.setVersion(version);
 
-                        getLogger().info("\tArchetype " + archetype + " defined by repository path");
+                        LOGGER.info("\tArchetype " + archetype + " defined by repository path");
                     } // end if-else
 
                     catalog.addArchetype(archetype);
@@ -135,7 +137,7 @@ public class DefaultRepositoryCrawler extends AbstractLogEnabled implements Repo
             catalogWriter.write(fileWriter, archetypeCatalog);
             return true;
         } catch (IOException ex) {
-            getLogger().warn("Catalog can not be writen to " + archetypeCatalogFile, ex);
+            LOGGER.warn("Catalog can not be writen to " + archetypeCatalogFile, ex);
             return false;
         }
     }

--- a/archetype-common/src/main/java/org/apache/maven/archetype/repositorycrawler/DefaultRepositoryCrawler.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/repositorycrawler/DefaultRepositoryCrawler.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
 @Singleton
 public class DefaultRepositoryCrawler implements RepositoryCrawler {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultRepositoryCrawler.class);
+
     @Inject
     private ArchetypeArtifactManager archetypeArtifactManager;
 

--- a/archetype-common/src/main/java/org/apache/maven/archetype/source/CatalogArchetypeDataSource.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/source/CatalogArchetypeDataSource.java
@@ -26,14 +26,16 @@ import java.io.Writer;
 import org.apache.maven.archetype.catalog.ArchetypeCatalog;
 import org.apache.maven.archetype.catalog.io.xpp3.ArchetypeCatalogXpp3Reader;
 import org.apache.maven.archetype.catalog.io.xpp3.ArchetypeCatalogXpp3Writer;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.xml.XmlStreamWriter;
 import org.codehaus.plexus.util.xml.pull.XmlPullParserException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Jason van Zyl
  */
-public abstract class CatalogArchetypeDataSource extends AbstractLogEnabled implements ArchetypeDataSource {
+public abstract class CatalogArchetypeDataSource implements ArchetypeDataSource {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CatalogArchetypeDataSource.class);
 
     protected void writeLocalCatalog(ArchetypeCatalog catalog, File catalogFile) throws ArchetypeDataSourceException {
         try (Writer writer = new XmlStreamWriter(catalogFile)) {

--- a/archetype-common/src/main/java/org/apache/maven/archetype/source/InternalCatalogArchetypeDataSource.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/source/InternalCatalogArchetypeDataSource.java
@@ -32,6 +32,8 @@ import org.apache.maven.archetype.catalog.ArchetypeCatalog;
 import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Jason van Zyl
@@ -39,6 +41,7 @@ import org.eclipse.aether.repository.RemoteRepository;
 @Named("internal-catalog")
 @Singleton
 public class InternalCatalogArchetypeDataSource extends CatalogArchetypeDataSource {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InternalCatalogArchetypeDataSource.class);
 
     @Override
     public ArchetypeCatalog getArchetypeCatalog(

--- a/archetype-common/src/main/java/org/apache/maven/archetype/source/LocalCatalogArchetypeDataSource.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/source/LocalCatalogArchetypeDataSource.java
@@ -33,10 +33,13 @@ import org.apache.maven.archetype.catalog.ArchetypeCatalog;
 import org.codehaus.plexus.util.xml.XmlStreamReader;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Named("catalog")
 @Singleton
 public class LocalCatalogArchetypeDataSource extends CatalogArchetypeDataSource {
+    private static final Logger LOGGER = LoggerFactory.getLogger(LocalCatalogArchetypeDataSource.class);
 
     @Override
     public File updateCatalog(RepositorySystemSession repositorySession, Archetype archetype)
@@ -45,21 +48,21 @@ public class LocalCatalogArchetypeDataSource extends CatalogArchetypeDataSource 
 
         File catalogFile = new File(localRepo, ARCHETYPE_CATALOG_FILENAME);
 
-        getLogger().debug("Catalog to be used for update: " + catalogFile.getAbsolutePath());
+        LOGGER.debug("Catalog to be used for update: " + catalogFile.getAbsolutePath());
 
         ArchetypeCatalog catalog;
         if (catalogFile.exists()) {
             try (Reader reader = new XmlStreamReader(catalogFile)) {
-                getLogger().debug("Reading catalog to be updated: " + catalogFile);
+                LOGGER.debug("Reading catalog to be updated: " + catalogFile);
                 catalog = readCatalog(reader);
             } catch (FileNotFoundException ex) {
-                getLogger().debug("Catalog file don't exist");
+                LOGGER.debug("Catalog file don't exist");
                 catalog = new ArchetypeCatalog();
             } catch (IOException e) {
                 throw new ArchetypeDataSourceException("Error reading archetype catalog.", e);
             }
         } else {
-            getLogger().debug("Catalog file don't exist");
+            LOGGER.debug("Catalog file don't exist");
             catalog = new ArchetypeCatalog();
         }
 
@@ -100,7 +103,7 @@ public class LocalCatalogArchetypeDataSource extends CatalogArchetypeDataSource 
         if (catalogFile.exists() && catalogFile.isDirectory()) {
             catalogFile = new File(catalogFile, ARCHETYPE_CATALOG_FILENAME);
         }
-        getLogger().debug("Getting archetypes from catalog: " + catalogFile);
+        LOGGER.debug("Getting archetypes from catalog: " + catalogFile);
 
         if (catalogFile.exists()) {
             try {

--- a/archetype-common/src/main/java/org/apache/maven/archetype/source/RemoteCatalogArchetypeDataSource.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/source/RemoteCatalogArchetypeDataSource.java
@@ -37,6 +37,8 @@ import org.eclipse.aether.metadata.Metadata;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.resolution.MetadataRequest;
 import org.eclipse.aether.resolution.MetadataResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * @author Jason van Zyl
@@ -44,6 +46,7 @@ import org.eclipse.aether.resolution.MetadataResult;
 @Named("remote-catalog")
 @Singleton
 public class RemoteCatalogArchetypeDataSource extends CatalogArchetypeDataSource implements ArchetypeDataSource {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RemoteCatalogArchetypeDataSource.class);
 
     @Inject
     private RepositorySystem repositorySystem;

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/DefaultArchetypeFactory.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/DefaultArchetypeFactory.java
@@ -210,8 +210,8 @@ public class DefaultArchetypeFactory implements ArchetypeFactory {
                 configuration.addRequiredProperty(requiredProperty);
 
                 configuration.setProperty(requiredProperty, properties.getProperty(requiredProperty));
-                LOGGER.debug("Setting property " + requiredProperty + "="
-                                + configuration.getProperty(requiredProperty));
+                LOGGER.debug(
+                        "Setting property " + requiredProperty + "=" + configuration.getProperty(requiredProperty));
             }
         }
 

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/DefaultArchetypeFactory.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/DefaultArchetypeFactory.java
@@ -27,11 +27,14 @@ import java.util.Properties;
 import org.apache.maven.archetype.common.Constants;
 import org.apache.maven.archetype.metadata.RequiredProperty;
 import org.apache.maven.project.MavenProject;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Named("default")
 @Singleton
-public class DefaultArchetypeFactory extends AbstractLogEnabled implements ArchetypeFactory {
+public class DefaultArchetypeFactory implements ArchetypeFactory {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArchetypeFactory.class);
+
     @Override
     public ArchetypeDefinition createArchetypeDefinition(Properties properties) {
         ArchetypeDefinition definition = new ArchetypeDefinition();
@@ -57,7 +60,7 @@ public class DefaultArchetypeFactory extends AbstractLogEnabled implements Arche
             String key,
             String defaultValue,
             boolean initPropertyWithDefault) {
-        getLogger().debug("Adding requiredProperty " + key);
+        LOGGER.debug("Adding requiredProperty " + key);
 
         configuration.addRequiredProperty(key);
 
@@ -73,14 +76,14 @@ public class DefaultArchetypeFactory extends AbstractLogEnabled implements Arche
             configuration.setDefaultProperty(key, defaultValue);
         }
 
-        getLogger().debug("Setting property " + key + "=" + configuration.getProperty(key));
+        LOGGER.debug("Setting property " + key + "=" + configuration.getProperty(key));
     }
 
     @Override
     @SuppressWarnings("checkstyle:linelength")
     public ArchetypeConfiguration createArchetypeConfiguration(
             org.apache.maven.archetype.old.descriptor.ArchetypeDescriptor archetypeDescriptor, Properties properties) {
-        getLogger().debug("Creating ArchetypeConfiguration from legacy descriptor and Properties");
+        LOGGER.debug("Creating ArchetypeConfiguration from legacy descriptor and Properties");
 
         ArchetypeConfiguration configuration = createArchetypeConfiguration(properties);
 
@@ -113,7 +116,7 @@ public class DefaultArchetypeFactory extends AbstractLogEnabled implements Arche
     @SuppressWarnings("checkstyle:linelength")
     public ArchetypeConfiguration createArchetypeConfiguration(
             org.apache.maven.archetype.metadata.ArchetypeDescriptor archetypeDescriptor, Properties properties) {
-        getLogger().debug("Creating ArchetypeConfiguration from fileset descriptor and Properties");
+        LOGGER.debug("Creating ArchetypeConfiguration from fileset descriptor and Properties");
 
         ArchetypeConfiguration configuration = createArchetypeConfiguration(properties);
 
@@ -121,7 +124,7 @@ public class DefaultArchetypeFactory extends AbstractLogEnabled implements Arche
 
         for (RequiredProperty requiredProperty : archetypeDescriptor.getRequiredProperties()) {
             String key = requiredProperty.getKey();
-            getLogger().debug("Adding requiredProperty " + key);
+            LOGGER.debug("Adding requiredProperty " + key);
 
             configuration.addRequiredProperty(key);
 
@@ -132,21 +135,21 @@ public class DefaultArchetypeFactory extends AbstractLogEnabled implements Arche
                 // using value defined in properties, which overrides any default
                 String value = properties.getProperty(key);
                 configuration.setProperty(key, value);
-                getLogger().debug("Setting property " + key + "=" + value);
+                LOGGER.debug("Setting property " + key + "=" + value);
             } else if ((defaultValue != null) && !containsInnerProperty(defaultValue)) {
                 // using default value
                 configuration.setProperty(key, defaultValue);
-                getLogger().debug("Setting property " + key + "=" + defaultValue);
+                LOGGER.debug("Setting property " + key + "=" + defaultValue);
             }
 
             if (defaultValue != null) {
                 configuration.setDefaultProperty(key, defaultValue);
-                getLogger().debug("Setting defaultProperty " + key + "=" + defaultValue);
+                LOGGER.debug("Setting defaultProperty " + key + "=" + defaultValue);
             }
 
             if (validationRegex != null) {
                 configuration.setPropertyValidationRegex(key, validationRegex);
-                getLogger().debug("Setting validation regular expression " + key + "=" + defaultValue);
+                LOGGER.debug("Setting validation regular expression " + key + "=" + defaultValue);
             }
         }
 
@@ -169,7 +172,7 @@ public class DefaultArchetypeFactory extends AbstractLogEnabled implements Arche
 
     private void addRequiredProperty(
             ArchetypeConfiguration configuration, Properties properties, String key, String defaultValue) {
-        getLogger().debug("Adding requiredProperty " + key);
+        LOGGER.debug("Adding requiredProperty " + key);
 
         configuration.addRequiredProperty(key);
 
@@ -180,7 +183,7 @@ public class DefaultArchetypeFactory extends AbstractLogEnabled implements Arche
         if (properties.getProperty(key) != null) {
             configuration.setProperty(key, properties.getProperty(key));
 
-            getLogger().debug("Setting property " + key + "=" + configuration.getProperty(Constants.GROUP_ID));
+            LOGGER.debug("Setting property " + key + "=" + configuration.getProperty(Constants.GROUP_ID));
         }
     }
 
@@ -195,7 +198,7 @@ public class DefaultArchetypeFactory extends AbstractLogEnabled implements Arche
     @Override
     public ArchetypeConfiguration createArchetypeConfiguration(
             MavenProject project, ArchetypeDefinition archetypeDefinition, Properties properties) {
-        getLogger().debug("Creating ArchetypeConfiguration from ArchetypeDefinition, MavenProject and Properties");
+        LOGGER.debug("Creating ArchetypeConfiguration from ArchetypeDefinition, MavenProject and Properties");
 
         ArchetypeConfiguration configuration = createArchetypeConfiguration(properties);
 
@@ -203,12 +206,11 @@ public class DefaultArchetypeFactory extends AbstractLogEnabled implements Arche
             String requiredProperty = (String) requiredProperties.next();
 
             if (!requiredProperty.contains(".")) {
-                getLogger().debug("Adding requiredProperty " + requiredProperty);
+                LOGGER.debug("Adding requiredProperty " + requiredProperty);
                 configuration.addRequiredProperty(requiredProperty);
 
                 configuration.setProperty(requiredProperty, properties.getProperty(requiredProperty));
-                getLogger()
-                        .debug("Setting property " + requiredProperty + "="
+                LOGGER.debug("Setting property " + requiredProperty + "="
                                 + configuration.getProperty(requiredProperty));
             }
         }

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/creation/DefaultArchetypeCreationConfigurator.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/creation/DefaultArchetypeCreationConfigurator.java
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
 @Singleton
 public class DefaultArchetypeCreationConfigurator implements ArchetypeCreationConfigurator {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArchetypeCreationConfigurator.class);
+
     @Inject
     private ArchetypeCreationQueryer archetypeCreationQueryer;
 

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/creation/DefaultArchetypeCreationConfigurator.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/creation/DefaultArchetypeCreationConfigurator.java
@@ -39,12 +39,14 @@ import org.apache.maven.archetype.ui.ArchetypeDefinition;
 import org.apache.maven.archetype.ui.ArchetypeFactory;
 import org.apache.maven.project.MavenProject;
 import org.codehaus.plexus.components.interactivity.PrompterException;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Named("default")
 @Singleton
-public class DefaultArchetypeCreationConfigurator extends AbstractLogEnabled implements ArchetypeCreationConfigurator {
+public class DefaultArchetypeCreationConfigurator implements ArchetypeCreationConfigurator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArchetypeCreationConfigurator.class);
     @Inject
     private ArchetypeCreationQueryer archetypeCreationQueryer;
 
@@ -81,25 +83,25 @@ public class DefaultArchetypeCreationConfigurator extends AbstractLogEnabled imp
         }
 
         if (interactiveMode.booleanValue()) {
-            getLogger().debug("Entering interactive mode");
+            LOGGER.debug("Entering interactive mode");
 
             boolean confirmed = false;
             while (!confirmed) {
                 if (!archetypeDefinition.isDefined()) // <editor-fold text="...">
                 {
-                    getLogger().debug("Archetype is yet not defined");
+                    LOGGER.debug("Archetype is yet not defined");
                     if (!archetypeDefinition.isGroupDefined()) {
-                        getLogger().debug("Asking for archetype's groupId");
+                        LOGGER.debug("Asking for archetype's groupId");
                         archetypeDefinition.setGroupId(
                                 archetypeCreationQueryer.getArchetypeGroupId(project.getGroupId()));
                     }
                     if (!archetypeDefinition.isArtifactDefined()) {
-                        getLogger().debug("Asking for archetype's artifactId");
+                        LOGGER.debug("Asking for archetype's artifactId");
                         archetypeDefinition.setArtifactId(archetypeCreationQueryer.getArchetypeArtifactId(
                                 project.getArtifactId() + Constants.ARCHETYPE_SUFFIX));
                     }
                     if (!archetypeDefinition.isVersionDefined()) {
-                        getLogger().debug("Asking for archetype's version");
+                        LOGGER.debug("Asking for archetype's version");
                         archetypeDefinition.setVersion(
                                 archetypeCreationQueryer.getArchetypeVersion(project.getVersion()));
                     }
@@ -109,30 +111,30 @@ public class DefaultArchetypeCreationConfigurator extends AbstractLogEnabled imp
 
                 if (!archetypeConfiguration.isConfigured()) // <editor-fold text="...">
                 {
-                    getLogger().debug("Archetype is not yet configured");
+                    LOGGER.debug("Archetype is not yet configured");
                     if (!archetypeConfiguration.isConfigured(Constants.GROUP_ID)) {
-                        getLogger().debug("Asking for project's groupId");
+                        LOGGER.debug("Asking for project's groupId");
                         archetypeConfiguration.setProperty(
                                 Constants.GROUP_ID,
                                 archetypeCreationQueryer.getGroupId(
                                         archetypeConfiguration.getDefaultValue(Constants.GROUP_ID)));
                     }
                     if (!archetypeConfiguration.isConfigured(Constants.ARTIFACT_ID)) {
-                        getLogger().debug("Asking for project's artifactId");
+                        LOGGER.debug("Asking for project's artifactId");
                         archetypeConfiguration.setProperty(
                                 Constants.ARTIFACT_ID,
                                 archetypeCreationQueryer.getArtifactId(
                                         archetypeConfiguration.getDefaultValue(Constants.ARTIFACT_ID)));
                     }
                     if (!archetypeConfiguration.isConfigured(Constants.VERSION)) {
-                        getLogger().debug("Asking for project's version");
+                        LOGGER.debug("Asking for project's version");
                         archetypeConfiguration.setProperty(
                                 Constants.VERSION,
                                 archetypeCreationQueryer.getVersion(
                                         archetypeConfiguration.getDefaultValue(Constants.VERSION)));
                     }
                     if (!archetypeConfiguration.isConfigured(Constants.PACKAGE)) {
-                        getLogger().debug("Asking for project's package");
+                        LOGGER.debug("Asking for project's package");
                         archetypeConfiguration.setProperty(
                                 Constants.PACKAGE,
                                 archetypeCreationQueryer.getPackage(
@@ -144,14 +146,14 @@ public class DefaultArchetypeCreationConfigurator extends AbstractLogEnabled imp
 
                 boolean stopAddingProperties = false;
                 while (!stopAddingProperties) {
-                    getLogger().debug("Asking for another required property");
+                    LOGGER.debug("Asking for another required property");
                     stopAddingProperties = !archetypeCreationQueryer.askAddAnotherProperty();
 
                     if (!stopAddingProperties) {
-                        getLogger().debug("Asking for required property key");
+                        LOGGER.debug("Asking for required property key");
 
                         String propertyKey = archetypeCreationQueryer.askNewPropertyKey();
-                        getLogger().debug("Asking for required property value");
+                        LOGGER.debug("Asking for required property value");
 
                         String replacementValue = archetypeCreationQueryer.askReplacementValue(
                                 propertyKey, archetypeConfiguration.getDefaultValue(propertyKey));
@@ -160,17 +162,17 @@ public class DefaultArchetypeCreationConfigurator extends AbstractLogEnabled imp
                     }
                 }
 
-                getLogger().debug("Asking for configuration confirmation");
+                LOGGER.debug("Asking for configuration confirmation");
                 if (archetypeCreationQueryer.confirmConfiguration(archetypeConfiguration)) {
                     confirmed = true;
                 } else {
-                    getLogger().debug("Reseting archetype's definition and configuration");
+                    LOGGER.debug("Reseting archetype's definition and configuration");
                     archetypeConfiguration.reset();
                     archetypeDefinition.reset();
                 }
             } // end while
         } else {
-            getLogger().debug("Entering batch mode");
+            LOGGER.debug("Entering batch mode");
             if (!archetypeDefinition.isDefined()) {
                 throw new ArchetypeNotDefined("The archetype is not defined");
             } else if (!archetypeConfiguration.isConfigured()) {
@@ -202,33 +204,33 @@ public class DefaultArchetypeCreationConfigurator extends AbstractLogEnabled imp
             String resolvedPackage,
             Properties properties) {
         if (StringUtils.isEmpty(properties.getProperty(Constants.GROUP_ID))) {
-            getLogger().info("Setting default groupId: " + project.getGroupId());
+            LOGGER.info("Setting default groupId: " + project.getGroupId());
             properties.setProperty(Constants.GROUP_ID, project.getGroupId());
         }
 
         if (StringUtils.isEmpty(properties.getProperty(Constants.ARTIFACT_ID))) {
-            getLogger().info("Setting default artifactId: " + project.getArtifactId());
+            LOGGER.info("Setting default artifactId: " + project.getArtifactId());
             properties.setProperty(Constants.ARTIFACT_ID, project.getArtifactId());
         }
 
         if (StringUtils.isEmpty(properties.getProperty(Constants.VERSION))) {
-            getLogger().info("Setting default version: " + project.getVersion());
+            LOGGER.info("Setting default version: " + project.getVersion());
             properties.setProperty(Constants.VERSION, project.getVersion());
         }
 
         if (StringUtils.isEmpty(properties.getProperty(Constants.ARCHETYPE_GROUP_ID))) {
-            getLogger().info("Setting default archetype's groupId: " + project.getGroupId());
+            LOGGER.info("Setting default archetype's groupId: " + project.getGroupId());
             properties.setProperty(Constants.ARCHETYPE_GROUP_ID, project.getGroupId());
         }
 
         if (StringUtils.isEmpty(properties.getProperty(Constants.ARCHETYPE_ARTIFACT_ID))) {
-            getLogger().info("Setting default archetype's artifactId: " + project.getArtifactId());
+            LOGGER.info("Setting default archetype's artifactId: " + project.getArtifactId());
             properties.setProperty(
                     Constants.ARCHETYPE_ARTIFACT_ID, project.getArtifactId() + Constants.ARCHETYPE_SUFFIX);
         }
 
         if (StringUtils.isEmpty(properties.getProperty(Constants.ARCHETYPE_VERSION))) {
-            getLogger().info("Setting default archetype's version: " + project.getVersion());
+            LOGGER.info("Setting default archetype's version: " + project.getVersion());
             properties.setProperty(Constants.ARCHETYPE_VERSION, project.getVersion());
         }
 
@@ -237,7 +239,7 @@ public class DefaultArchetypeCreationConfigurator extends AbstractLogEnabled imp
             if (resolvedPackage == null || resolvedPackage.isEmpty()) {
                 resolvedPackage = project.getGroupId();
             }
-            getLogger().info("Setting default package: " + resolvedPackage);
+            LOGGER.info("Setting default package: " + resolvedPackage);
             /* properties.setProperty ( Constants.PACKAGE_NAME, resolvedPackage ); */
             properties.setProperty(Constants.PACKAGE, resolvedPackage);
         }
@@ -246,12 +248,12 @@ public class DefaultArchetypeCreationConfigurator extends AbstractLogEnabled imp
     }
 
     private void readProperties(Properties properties, File propertyFile) throws IOException {
-        getLogger().debug("Reading property file " + propertyFile);
+        LOGGER.debug("Reading property file " + propertyFile);
 
         try (InputStream is = Files.newInputStream(propertyFile.toPath())) {
             properties.load(is);
 
-            getLogger().debug("Read " + properties.size() + " properties");
+            LOGGER.debug("Read " + properties.size() + " properties");
         }
     }
 
@@ -263,7 +265,7 @@ public class DefaultArchetypeCreationConfigurator extends AbstractLogEnabled imp
             try {
                 readProperties(properties, propertyFile);
             } catch (NoSuchFileException ex) {
-                getLogger().debug(propertyFile.getName() + "  does not exist");
+                LOGGER.debug(propertyFile.getName() + "  does not exist");
             }
         }
 

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/creation/DefaultArchetypeCreationQueryer.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/creation/DefaultArchetypeCreationQueryer.java
@@ -28,11 +28,13 @@ import org.apache.maven.archetype.common.Constants;
 import org.apache.maven.archetype.ui.ArchetypeConfiguration;
 import org.codehaus.plexus.components.interactivity.Prompter;
 import org.codehaus.plexus.components.interactivity.PrompterException;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Named("default")
 @Singleton
-public class DefaultArchetypeCreationQueryer extends AbstractLogEnabled implements ArchetypeCreationQueryer {
+public class DefaultArchetypeCreationQueryer implements ArchetypeCreationQueryer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArchetypeCreationQueryer.class);
     @Inject
     private Prompter prompter;
 

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/creation/DefaultArchetypeCreationQueryer.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/creation/DefaultArchetypeCreationQueryer.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 @Singleton
 public class DefaultArchetypeCreationQueryer implements ArchetypeCreationQueryer {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArchetypeCreationQueryer.class);
+
     @Inject
     private Prompter prompter;
 

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeGenerationConfigurator.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeGenerationConfigurator.java
@@ -57,19 +57,21 @@ import org.apache.velocity.runtime.parser.node.ASTReference;
 import org.apache.velocity.runtime.parser.node.SimpleNode;
 import org.apache.velocity.runtime.visitor.BaseVisitor;
 import org.codehaus.plexus.components.interactivity.PrompterException;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.velocity.VelocityComponent;
 import org.eclipse.aether.RepositorySystem;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
 import org.eclipse.aether.repository.RepositoryPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 // TODO: this seems to have more responsibilities than just a configurator
 @Named("default")
 @Singleton
-public class DefaultArchetypeGenerationConfigurator extends AbstractLogEnabled
+public class DefaultArchetypeGenerationConfigurator
         implements ArchetypeGenerationConfigurator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArchetypeGenerationConfigurator.class);
 
     @Inject
     private ArchetypeArtifactManager archetypeArtifactManager;
@@ -159,8 +161,7 @@ public class DefaultArchetypeGenerationConfigurator extends AbstractLogEnabled
             while (!confirmed) {
                 if (archetypeConfiguration.isConfigured()) {
                     for (String requiredProperty : propertiesRequired) {
-                        getLogger()
-                                .info("Using property: " + requiredProperty + " = "
+                        LOGGER.info("Using property: " + requiredProperty + " = "
                                         + archetypeConfiguration.getProperty(requiredProperty));
                     }
                 } else {
@@ -169,8 +170,7 @@ public class DefaultArchetypeGenerationConfigurator extends AbstractLogEnabled
 
                         if (archetypeConfiguration.isConfigured(requiredProperty)
                                 && !request.isAskForDefaultPropertyValues()) {
-                            getLogger()
-                                    .info("Using property: " + requiredProperty + " = "
+                            LOGGER.info("Using property: " + requiredProperty + " = "
                                             + archetypeConfiguration.getProperty(requiredProperty));
 
                             value = archetypeConfiguration.getProperty(requiredProperty);
@@ -194,13 +194,13 @@ public class DefaultArchetypeGenerationConfigurator extends AbstractLogEnabled
                 }
 
                 if (!archetypeConfiguration.isConfigured()) {
-                    getLogger().warn("Archetype is not fully configured");
+                    LOGGER.warn("Archetype is not fully configured");
                 } else if (!archetypeGenerationQueryer.confirmConfiguration(archetypeConfiguration)) {
-                    getLogger().debug("Archetype generation configuration not confirmed");
+                    LOGGER.debug("Archetype generation configuration not confirmed");
                     archetypeConfiguration.reset();
                     restoreCommandLineProperties(archetypeConfiguration, executionProperties);
                 } else {
-                    getLogger().debug("Archetype generation configuration confirmed");
+                    LOGGER.debug("Archetype generation configuration confirmed");
 
                     confirmed = true;
                 }
@@ -239,8 +239,7 @@ public class DefaultArchetypeGenerationConfigurator extends AbstractLogEnabled
                             exceptionMessage.append(requiredProperty);
                             missingProperties.add(requiredProperty);
                             exceptionMessage.append(" is missing.");
-                            getLogger()
-                                    .warn("Property " + requiredProperty + " is missing. Add -D" + requiredProperty
+                            LOGGER.warn("Property " + requiredProperty + " is missing. Add -D" + requiredProperty
                                             + "=someValue");
                         }
                     }
@@ -278,12 +277,12 @@ public class DefaultArchetypeGenerationConfigurator extends AbstractLogEnabled
 
     private void restoreCommandLineProperties(
             ArchetypeConfiguration archetypeConfiguration, Properties executionProperties) {
-        getLogger().debug("Restoring command line properties");
+        LOGGER.debug("Restoring command line properties");
 
         for (String property : archetypeConfiguration.getRequiredProperties()) {
             if (executionProperties.containsKey(property)) {
                 archetypeConfiguration.setProperty(property, executionProperties.getProperty(property));
-                getLogger().debug("Restored " + property + "=" + archetypeConfiguration.getProperty(property));
+                LOGGER.debug("Restored " + property + "=" + archetypeConfiguration.getProperty(property));
             }
         }
     }

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeGenerationConfigurator.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeGenerationConfigurator.java
@@ -69,8 +69,7 @@ import org.slf4j.LoggerFactory;
 // TODO: this seems to have more responsibilities than just a configurator
 @Named("default")
 @Singleton
-public class DefaultArchetypeGenerationConfigurator
-        implements ArchetypeGenerationConfigurator {
+public class DefaultArchetypeGenerationConfigurator implements ArchetypeGenerationConfigurator {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArchetypeGenerationConfigurator.class);
 
     @Inject
@@ -162,7 +161,7 @@ public class DefaultArchetypeGenerationConfigurator
                 if (archetypeConfiguration.isConfigured()) {
                     for (String requiredProperty : propertiesRequired) {
                         LOGGER.info("Using property: " + requiredProperty + " = "
-                                        + archetypeConfiguration.getProperty(requiredProperty));
+                                + archetypeConfiguration.getProperty(requiredProperty));
                     }
                 } else {
                     for (String requiredProperty : propertiesRequired) {
@@ -171,7 +170,7 @@ public class DefaultArchetypeGenerationConfigurator
                         if (archetypeConfiguration.isConfigured(requiredProperty)
                                 && !request.isAskForDefaultPropertyValues()) {
                             LOGGER.info("Using property: " + requiredProperty + " = "
-                                            + archetypeConfiguration.getProperty(requiredProperty));
+                                    + archetypeConfiguration.getProperty(requiredProperty));
 
                             value = archetypeConfiguration.getProperty(requiredProperty);
                         } else {
@@ -240,7 +239,7 @@ public class DefaultArchetypeGenerationConfigurator
                             missingProperties.add(requiredProperty);
                             exceptionMessage.append(" is missing.");
                             LOGGER.warn("Property " + requiredProperty + " is missing. Add -D" + requiredProperty
-                                            + "=someValue");
+                                    + "=someValue");
                         }
                     }
 

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeGenerationQueryer.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeGenerationQueryer.java
@@ -27,11 +27,13 @@ import java.util.regex.Pattern;
 import org.apache.maven.archetype.ui.ArchetypeConfiguration;
 import org.codehaus.plexus.components.interactivity.Prompter;
 import org.codehaus.plexus.components.interactivity.PrompterException;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Named("default")
 @Singleton
-public class DefaultArchetypeGenerationQueryer extends AbstractLogEnabled implements ArchetypeGenerationQueryer {
+public class DefaultArchetypeGenerationQueryer implements ArchetypeGenerationQueryer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArchetypeGenerationQueryer.class);
     @Inject
     private Prompter prompter;
 

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeGenerationQueryer.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeGenerationQueryer.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 @Singleton
 public class DefaultArchetypeGenerationQueryer implements ArchetypeGenerationQueryer {
     private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArchetypeGenerationQueryer.class);
+
     @Inject
     private Prompter prompter;
 

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeSelectionQueryer.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeSelectionQueryer.java
@@ -38,11 +38,13 @@ import org.apache.maven.artifact.versioning.ArtifactVersion;
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion;
 import org.codehaus.plexus.components.interactivity.Prompter;
 import org.codehaus.plexus.components.interactivity.PrompterException;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Named("default")
 @Singleton
-public class DefaultArchetypeSelectionQueryer extends AbstractLogEnabled implements ArchetypeSelectionQueryer {
+public class DefaultArchetypeSelectionQueryer implements ArchetypeSelectionQueryer {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArchetypeSelectionQueryer.class);
 
     @Inject
     @Named("archetype")

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeSelector.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeSelector.java
@@ -34,13 +34,15 @@ import org.apache.maven.archetype.catalog.Archetype;
 import org.apache.maven.archetype.exception.ArchetypeSelectionFailure;
 import org.apache.maven.archetype.ui.ArchetypeDefinition;
 import org.codehaus.plexus.components.interactivity.PrompterException;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
 import org.eclipse.aether.RepositorySystemSession;
 import org.eclipse.aether.repository.RemoteRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Named("default")
 @Singleton
-public class DefaultArchetypeSelector extends AbstractLogEnabled implements ArchetypeSelector {
+public class DefaultArchetypeSelector implements ArchetypeSelector {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DefaultArchetypeSelector.class);
     static final String DEFAULT_ARCHETYPE_GROUPID = "org.apache.maven.archetypes";
 
     static final String DEFAULT_ARCHETYPE_VERSION = "1.0";
@@ -59,7 +61,7 @@ public class DefaultArchetypeSelector extends AbstractLogEnabled implements Arch
         ArchetypeDefinition definition = new ArchetypeDefinition(request);
 
         if (definition.isDefined() && StringUtils.isNotEmpty(request.getArchetypeRepository())) {
-            getLogger().info("Archetype defined by properties");
+            LOGGER.info("Archetype defined by properties");
             return;
         }
 
@@ -70,7 +72,7 @@ public class DefaultArchetypeSelector extends AbstractLogEnabled implements Arch
             // applying some filtering depending on filter parameter
             archetypes = ArchetypeSelectorUtils.getFilteredArchetypesByCatalog(archetypes, request.getFilter());
             if (archetypes.isEmpty()) {
-                getLogger().info("Your filter doesn't match any archetype, so try again with another value.");
+                LOGGER.info("Your filter doesn't match any archetype, so try again with another value.");
                 return;
             }
         }
@@ -85,13 +87,11 @@ public class DefaultArchetypeSelector extends AbstractLogEnabled implements Arch
 
                 updateRepository(definition, archetype);
 
-                getLogger()
-                        .info("Archetype repository not defined. Using the one from " + archetype + " found in catalog "
+                LOGGER.info("Archetype repository not defined. Using the one from " + archetype + " found in catalog "
                                 + catalogKey);
             } else {
-                getLogger().warn("Archetype not found in any catalog. Falling back to central repository.");
-                getLogger()
-                        .warn(
+                LOGGER.warn("Archetype not found in any catalog. Falling back to central repository.");
+                LOGGER.warn(
                                 "Add a repository with id 'archetype' in your settings.xml if archetype's repository is elsewhere.");
             }
         } else if (definition.isPartiallyDefined()) {
@@ -104,9 +104,9 @@ public class DefaultArchetypeSelector extends AbstractLogEnabled implements Arch
 
                 updateDefinition(definition, archetype);
 
-                getLogger().info("Archetype " + archetype + " found in catalog " + catalogKey);
+                LOGGER.info("Archetype " + archetype + " found in catalog " + catalogKey);
             } else {
-                getLogger().warn("Specified archetype not found.");
+                LOGGER.warn("Specified archetype not found.");
                 if (interactiveMode.booleanValue()) {
                     definition.setVersion(null);
                     definition.setGroupId(null);
@@ -126,8 +126,7 @@ public class DefaultArchetypeSelector extends AbstractLogEnabled implements Arch
         if (!definition.isPartiallyDefined()) {
             // if artifact ID is set to its default, we still prompt to confirm
             if (definition.getArtifactId() == null) {
-                getLogger()
-                        .info("No archetype defined. Using " + DEFAULT_ARCHETYPE_ARTIFACTID + " ("
+                LOGGER.info("No archetype defined. Using " + DEFAULT_ARCHETYPE_ARTIFACTID + " ("
                                 + definition.getGroupId() + ":" + DEFAULT_ARCHETYPE_ARTIFACTID + ":"
                                 + definition.getVersion() + ")");
                 definition.setArtifactId(DEFAULT_ARCHETYPE_ARTIFACTID);
@@ -173,7 +172,7 @@ public class DefaultArchetypeSelector extends AbstractLogEnabled implements Arch
                 if (!archetypesFromRemote.isEmpty()) {
                     archetypes.put("remote", archetypesFromRemote);
                 } else {
-                    getLogger().warn("No archetype found in remote catalog. Defaulting to internal catalog");
+                    LOGGER.warn("No archetype found in remote catalog. Defaulting to internal catalog");
                     archetypes.put(
                             "internal", archetypeManager.getInternalCatalog().getArchetypes());
                 }
@@ -184,7 +183,7 @@ public class DefaultArchetypeSelector extends AbstractLogEnabled implements Arch
         }
 
         if (archetypes.isEmpty()) {
-            getLogger().info("No catalog defined. Using internal catalog");
+            LOGGER.info("No catalog defined. Using internal catalog");
 
             archetypes.put("internal", archetypeManager.getInternalCatalog().getArchetypes());
         }

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeSelector.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/DefaultArchetypeSelector.java
@@ -88,11 +88,11 @@ public class DefaultArchetypeSelector implements ArchetypeSelector {
                 updateRepository(definition, archetype);
 
                 LOGGER.info("Archetype repository not defined. Using the one from " + archetype + " found in catalog "
-                                + catalogKey);
+                        + catalogKey);
             } else {
                 LOGGER.warn("Archetype not found in any catalog. Falling back to central repository.");
                 LOGGER.warn(
-                                "Add a repository with id 'archetype' in your settings.xml if archetype's repository is elsewhere.");
+                        "Add a repository with id 'archetype' in your settings.xml if archetype's repository is elsewhere.");
             }
         } else if (definition.isPartiallyDefined()) {
             Map.Entry<String, Archetype> found =
@@ -127,8 +127,8 @@ public class DefaultArchetypeSelector implements ArchetypeSelector {
             // if artifact ID is set to its default, we still prompt to confirm
             if (definition.getArtifactId() == null) {
                 LOGGER.info("No archetype defined. Using " + DEFAULT_ARCHETYPE_ARTIFACTID + " ("
-                                + definition.getGroupId() + ":" + DEFAULT_ARCHETYPE_ARTIFACTID + ":"
-                                + definition.getVersion() + ")");
+                        + definition.getGroupId() + ":" + DEFAULT_ARCHETYPE_ARTIFACTID + ":"
+                        + definition.getVersion() + ")");
                 definition.setArtifactId(DEFAULT_ARCHETYPE_ARTIFACTID);
             }
 


### PR DESCRIPTION
As seen on https://cwiki.apache.org/confluence/plugins/servlet/mobile?contentId=181305684#MavenEcosystemCleanup-DropPlexusContainerforJSR-330+SisuGuiceextension

- Leverages https://github.com/openrewrite/rewrite-apache/pull/41

@elharo if you wouldn't mind, could you look this over?

Use this link to re-run the recipe: https://app.moderne.io/builder/LgpIkYTbY?organizationId=ZTY0ODBjZGQtMTIyOC00MzA4LTlhZmQtODM2ZmYxOWFjNzM2

