### PR TITLE
Fix recognize project packaging by PomUtils

### DIFF
--- a/archetype-common/src/main/java/org/apache/maven/archetype/common/util/PomUtils.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/common/util/PomUtils.java
@@ -48,6 +48,7 @@ import org.xml.sax.SAXException;
  * POM helper class.
  */
 public final class PomUtils {
+
     private PomUtils() {
         throw new IllegalStateException("no instantiable constructor");
     }
@@ -89,16 +90,16 @@ public final class PomUtils {
         }
 
         String packaging = null;
-        NodeList packagingElement = project.getElementsByTagName("packaging");
-        if (packagingElement != null && packagingElement.getLength() == 1) {
-            packaging = packagingElement.item(0).getTextContent();
+        Node packagingNode = getChildNode(project, "packaging");
+        if (packagingNode != null) {
+            packaging = packagingNode.getTextContent();
         }
         if (!"pom".equals(packaging)) {
             throw new InvalidPackaging(
                     "Unable to add module to the current project as it is not of packaging type 'pom'");
         }
 
-        Node modules = getModulesNode(project);
+        Node modules = getChildNode(project, "modules");
 
         if (!hasArtifactIdInModules(artifactId, modules)) {
             Element module = document.createElement("module");
@@ -137,17 +138,17 @@ public final class PomUtils {
         }
     }
 
-    private static Node getModulesNode(Element project) {
-        Node modules = null;
-        NodeList nodes = project.getChildNodes();
+    private static Node getChildNode(Element parent, String name) {
+        Node namedNode = null;
+        NodeList nodes = parent.getChildNodes();
         for (int len = nodes.getLength(), i = 0; i < len; i++) {
             Node node = nodes.item(i);
-            if (node.getNodeType() == Node.ELEMENT_NODE && "modules".equals(node.getNodeName())) {
-                modules = node;
+            if (node.getNodeType() == Node.ELEMENT_NODE && name.equals(node.getNodeName())) {
+                namedNode = node;
                 break;
             }
         }
-        return modules;
+        return namedNode;
     }
 
     private static boolean hasArtifactIdInModules(String artifactId, Node modules) {

--- a/archetype-common/src/test/resources/projects/pom-manager/pom-sample-1.xml
+++ b/archetype-common/src/test/resources/projects/pom-manager/pom-sample-1.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.archetype</groupId>
+    <artifactId>pom-manager-1</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>Maven archetype Test Pom Manager</name>
+    <packaging>pom</packaging>
+
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.archetype</groupId>
+          <artifactId>test-maven-plugin</artifactId>
+          <configuration>
+            <packaging>jar</packaging>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
+</project>

--- a/archetype-common/src/test/resources/projects/pom-manager/pom-sample-2.xml
+++ b/archetype-common/src/test/resources/projects/pom-manager/pom-sample-2.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.archetype</groupId>
+    <artifactId>pom-manager-1</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>Maven archetype Test Pom Manager</name>
+    <packaging>jar</packaging>
+
+    <build>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.archetype</groupId>
+          <artifactId>test-maven-plugin</artifactId>
+          <configuration>
+            <packaging>pom</packaging>
+          </configuration>
+        </plugin>
+      </plugins>
+    </build>
+</project>


### PR DESCRIPTION
Check for packaging type pom relies now on child node of project.

fixes #263

In PomUtils the packagingNode was previously based on the method getElementsByTagName.
But using this method gets every node with name "packaging", not only the packaging node of
the project.

This was corrected by adapting the getModulesNode, changing its name to getModulesNode
and using the parameter name for the node to be returned.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. 
  Note that commits might be squashed by a maintainer on merge.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. 
  This may not always be possible but is a best-practice.
- [x] Run `mvn clean verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its clean verify`).


If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
