### PR TITLE
Lock down plugin versions in maven-archetype packaging

### DIFF
--- a/archetype-common/src/main/java/org/apache/maven/archetype/creator/FilesetArchetypeCreator.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/creator/FilesetArchetypeCreator.java
@@ -62,7 +62,6 @@ import org.apache.maven.model.Dependency;
 import org.apache.maven.model.Extension;
 import org.apache.maven.model.Model;
 import org.apache.maven.model.Plugin;
-import org.apache.maven.model.PluginManagement;
 import org.apache.maven.model.Profile;
 import org.apache.maven.model.Resource;
 import org.apache.maven.project.MavenProject;
@@ -426,15 +425,6 @@ public class FilesetArchetypeCreator implements ArchetypeCreator {
         extension.setArtifactId("archetype-packaging");
         extension.setVersion(getArchetypeVersion());
         model.getBuild().addExtension(extension);
-
-        Plugin plugin = new Plugin();
-        plugin.setGroupId("org.apache.maven.plugins");
-        plugin.setArtifactId("maven-archetype-plugin");
-        plugin.setVersion(getArchetypeVersion());
-
-        PluginManagement pluginManagement = new PluginManagement();
-        pluginManagement.addPlugin(plugin);
-        model.getBuild().setPluginManagement(pluginManagement);
 
         LOGGER.debug("Creating archetype's pom");
 

--- a/archetype-packaging/pom.xml
+++ b/archetype-packaging/pom.xml
@@ -31,4 +31,13 @@
   <name>Maven Archetype Packaging</name>
   <description>'maven-archetype' packaging configuration for archetypes.</description>
 
+  <build>
+    <resources>
+      <resource>
+        <filtering>true</filtering>
+        <directory>src/main/resources</directory>
+      </resource>
+    </resources>
+  </build>
+
 </project>

--- a/archetype-packaging/src/main/resources/META-INF/plexus/components.xml
+++ b/archetype-packaging/src/main/resources/META-INF/plexus/components.xml
@@ -26,15 +26,14 @@
       <configuration>
         <!-- START SNIPPET: maven-archetype-lifecycle -->
         <phases>
-          <process-resources>org.apache.maven.plugins:maven-resources-plugin:resources</process-resources>
-          <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:testResources</process-test-resources>
-          <package>org.apache.maven.plugins:maven-archetype-plugin:jar</package>
-          <integration-test>org.apache.maven.plugins:maven-archetype-plugin:integration-test</integration-test>
-          <install>org.apache.maven.plugins:maven-install-plugin:install,
-            org.apache.maven.plugins:maven-archetype-plugin:update-local-catalog
+          <process-resources>org.apache.maven.plugins:maven-resources-plugin:${version.maven-resources-plugin}:resources</process-resources>
+          <process-test-resources>org.apache.maven.plugins:maven-resources-plugin:${version.maven-resources-plugin}:testResources</process-test-resources>
+          <package>org.apache.maven.plugins:maven-archetype-plugin:${project.version}:jar</package>
+          <integration-test>org.apache.maven.plugins:maven-archetype-plugin:${project.version}:integration-test</integration-test>
+          <install>org.apache.maven.plugins:maven-install-plugin:${version.maven-install-plugin}:install,
+            org.apache.maven.plugins:maven-archetype-plugin:${project.version}:update-local-catalog
           </install>
-          <!-- Update the local catalog -->
-          <deploy>org.apache.maven.plugins:maven-deploy-plugin:deploy</deploy>
+          <deploy>org.apache.maven.plugins:maven-deploy-plugin:${version.maven-deploy-plugin}:deploy</deploy>
         </phases>
         <!-- END SNIPPET: maven-archetype-lifecycle -->
       </configuration>

--- a/archetype-packaging/src/site/apt/index.apt.vm
+++ b/archetype-packaging/src/site/apt/index.apt.vm
@@ -46,9 +46,7 @@ Usage
 
    Declaring <<<maven-archetype>>> packaging to your pom is not the only step required:
 
-   * to be available from an the archetype project, the packaging must be added as an extension,
-
-   * to ensure a reproducible build, the archetype plugin version needs to be locked down in pluginManagement section.
+   * to be available from the archetype project, the packaging must be added as an extension,
 
    []
 
@@ -67,16 +65,6 @@ Usage
         <version>${project.version}</version>
       </extension>
     </extensions>
-
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-archetype-plugin</artifactId>
-          <version>${project.version}</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
   </build>
 </project>
 +---

--- a/maven-archetype-plugin/src/it/projects/ARCHETYPE-241_filter-directory/archetype/pom.xml
+++ b/maven-archetype-plugin/src/it/projects/ARCHETYPE-241_filter-directory/archetype/pom.xml
@@ -31,11 +31,18 @@ under the License.
   <packaging>maven-archetype</packaging>
   
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.archetype</groupId>
+        <artifactId>archetype-packaging</artifactId>
+        <version>@project.version@</version>
+      </extension>
+    </extensions>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-archetype-plugin</artifactId>
-        <extensions>true</extensions>
         <configuration>
           <archetypeDirectory>src/main/resources</archetypeDirectory>
         </configuration>

--- a/maven-archetype-plugin/src/it/projects/ARCHETYPE-241_filter-directory/pom.xml
+++ b/maven-archetype-plugin/src/it/projects/ARCHETYPE-241_filter-directory/pom.xml
@@ -26,24 +26,9 @@ under the License.
   <artifactId>archetype241-parent</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  
-  <build>
-    <extensions>
-      <extension>
-        <groupId>org.apache.maven.archetype</groupId>
-        <artifactId>archetype-packaging</artifactId>
-        <version>@project.version@</version>
-      </extension>
-    </extensions>
-    
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-archetype-plugin</artifactId>
-          <version>@project.version@</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
+
+  <modules>
+    <module>archetype</module>
+  </modules>
+
 </project>

--- a/maven-archetype-plugin/src/it/projects/ARCHETYPE-536_groovy-grape/archetype/pom.xml
+++ b/maven-archetype-plugin/src/it/projects/ARCHETYPE-536_groovy-grape/archetype/pom.xml
@@ -31,6 +31,14 @@ under the License.
   <packaging>maven-archetype</packaging>
   
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.archetype</groupId>
+        <artifactId>archetype-packaging</artifactId>
+        <version>@project.version@</version>
+      </extension>
+    </extensions>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/maven-archetype-plugin/src/it/projects/ARCHETYPE-536_groovy-grape/pom.xml
+++ b/maven-archetype-plugin/src/it/projects/ARCHETYPE-536_groovy-grape/pom.xml
@@ -26,25 +26,9 @@ under the License.
   <artifactId>archetype536-parent</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  
-  <build>
-    <extensions>
-      <extension>
-        <groupId>org.apache.maven.archetype</groupId>
-        <artifactId>archetype-packaging</artifactId>
-        <version>@project.version@</version>
-      </extension>
-    </extensions>
-    
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-archetype-plugin</artifactId>
-          <version>@project.version@</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
+
+  <modules>
+    <module>archetype</module>
+  </modules>
 
 </project>

--- a/maven-archetype-plugin/src/it/projects/ARCHETYPE-679_groovy-modules/archetype/pom.xml
+++ b/maven-archetype-plugin/src/it/projects/ARCHETYPE-679_groovy-modules/archetype/pom.xml
@@ -31,6 +31,14 @@ under the License.
   <packaging>maven-archetype</packaging>
   
   <build>
+    <extensions>
+      <extension>
+        <groupId>org.apache.maven.archetype</groupId>
+        <artifactId>archetype-packaging</artifactId>
+        <version>@project.version@</version>
+      </extension>
+    </extensions>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/maven-archetype-plugin/src/it/projects/ARCHETYPE-679_groovy-modules/pom.xml
+++ b/maven-archetype-plugin/src/it/projects/ARCHETYPE-679_groovy-modules/pom.xml
@@ -26,25 +26,9 @@ under the License.
   <artifactId>archetype679-parent</artifactId>
   <version>1.0-SNAPSHOT</version>
   <packaging>pom</packaging>
-  
-  <build>
-    <extensions>
-      <extension>
-        <groupId>org.apache.maven.archetype</groupId>
-        <artifactId>archetype-packaging</artifactId>
-        <version>@project.version@</version>
-      </extension>
-    </extensions>
-    
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-archetype-plugin</artifactId>
-          <version>@project.version@</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
+
+  <modules>
+    <module>archetype</module>
+  </modules>
 
 </project>

--- a/maven-archetype-plugin/src/it/projects/build-and-run-its/pom.xml
+++ b/maven-archetype-plugin/src/it/projects/build-and-run-its/pom.xml
@@ -56,7 +56,6 @@ under the License.
             <properties>
               <maven.compiler.source>${maven.compiler.source}</maven.compiler.source>
               <maven.compiler.target>${maven.compiler.target}</maven.compiler.target>
-
             </properties>
           </configuration>
         </plugin>

--- a/maven-archetype-plugin/src/it/projects/build-ignore-eol/pom.xml
+++ b/maven-archetype-plugin/src/it/projects/build-ignore-eol/pom.xml
@@ -47,10 +47,6 @@ under the License.
     <pluginManagement>
       <plugins>
         <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.7.0</version>
-        </plugin>
-        <plugin>
           <artifactId>maven-archetype-plugin</artifactId>
           <version>@project.version@</version>
           <configuration>

--- a/maven-archetype-plugin/src/it/projects/create-4/pom.xml
+++ b/maven-archetype-plugin/src/it/projects/create-4/pom.xml
@@ -33,7 +33,7 @@
     <packaging>pom</packaging>
 
     <modules>
-    	<module>subModuleWar</module>
+        <module>subModuleWar</module>
         <module>subModuleEAR</module>
     </modules>
 </project>

--- a/maven-archetype-plugin/src/it/projects/create-5/pom.xml
+++ b/maven-archetype-plugin/src/it/projects/create-5/pom.xml
@@ -31,16 +31,4 @@
     <name>Maven archetype Test create-5</name>
     <packaging>pom</packaging>
 
-	<build>
-		<pluginManagement>
-			<plugins>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-ear-plugin</artifactId>
-					<version>2.10</version>
-				</plugin>
-			</plugins>
-		</pluginManagement>
-	</build>
-
 </project>


### PR DESCRIPTION
All versions for plugins used in packaging binding should be defined.
