### PR TITLE
[ARCHETYPE-548] Resource files without extension missing in create-from-project

### DIFF
--- a/archetype-common/src/main/java/org/apache/maven/archetype/creator/FilesetArchetypeCreator.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/creator/FilesetArchetypeCreator.java
@@ -1143,6 +1143,18 @@ public class FilesetArchetypeCreator implements ArchetypeCreator {
         return extensions;
     }
 
+    private Set<String> getExtensionlessFiles(List<String> files) {
+        Set<String> extensionlessFiles = new HashSet<>();
+
+        for (String file : files) {
+            if (FileUtils.extension(file).isEmpty()) {
+                extensionlessFiles.add(file);
+            }
+        }
+
+        return extensionlessFiles;
+    }
+
     private Map<String, List<String>> getGroupsMap(final List<String> files, final int level) {
         Map<String, List<String>> groups = new HashMap<>();
 
@@ -1613,12 +1625,18 @@ public class FilesetArchetypeCreator implements ArchetypeCreator {
     private FileSet getUnpackagedFileSet(
             final boolean filtered, final String group, final List<String> groupFiles, String defaultEncoding) {
         Set<String> extensions = getExtensions(groupFiles);
+        Set<String> extensionlessFiles = getExtensionlessFiles(groupFiles);
 
         List<String> includes = new ArrayList<>();
         List<String> excludes = new ArrayList<>();
 
         for (String extension : extensions) {
-            includes.add("**/*." + extension);
+            if (!extension.isEmpty()) {
+                includes.add("**/*." + extension);
+            }
+        }
+        for (String extensionlessFile : extensionlessFiles) {
+            includes.add("**/" + extensionlessFile);
         }
 
         return createFileSet(excludes, false, filtered, group, includes, defaultEncoding);

--- a/maven-archetype-plugin/src/it/projects/include-resource-file-with-no-extension/archetype.properties
+++ b/maven-archetype-plugin/src/it/projects/include-resource-file-with-no-extension/archetype.properties
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+archetype.groupId=org.codehaus.mojo.archetypes
+archetype.artifactId=maven-archetype-test
+archetype.version=1.0
+archetype.languages=csharp
+groupId=org.apache.maven.archetype.test
+artifactId=test
+version=1.0-SNAPSHOT
+package=archetype
+excludePatterns=build.log,invoker.properties,verify.groovy

--- a/maven-archetype-plugin/src/it/projects/include-resource-file-with-no-extension/invoker.properties
+++ b/maven-archetype-plugin/src/it/projects/include-resource-file-with-no-extension/invoker.properties
@@ -1,0 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = org.apache.maven.plugins:maven-archetype-plugin:${project.version}:create-from-project

--- a/maven-archetype-plugin/src/it/projects/include-resource-file-with-no-extension/pom.xml
+++ b/maven-archetype-plugin/src/it/projects/include-resource-file-with-no-extension/pom.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.archetype.test</groupId>
+    <artifactId>include-resource-file-with-no-extension</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>Maven archetype Test Include A Resource File With No Extension</name>
+    <packaging>pom</packaging>
+
+</project>

--- a/maven-archetype-plugin/src/it/projects/include-resource-file-with-no-extension/res/txt/filewithnoextension
+++ b/maven-archetype-plugin/src/it/projects/include-resource-file-with-no-extension/res/txt/filewithnoextension
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.

--- a/maven-archetype-plugin/src/it/projects/include-resource-file-with-no-extension/verify.groovy
+++ b/maven-archetype-plugin/src/it/projects/include-resource-file-with-no-extension/verify.groovy
@@ -1,0 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def templateDir = new File(basedir, 'target/generated-sources/archetype/src/main/resources/archetype-resources')
+
+assert new File(templateDir, 'res/txt/filewithnoextension').exists()


### PR DESCRIPTION
- Fixes resource files without extension not being included in mvn archetype:create-from-project
- Added integration test for resource file without extension

In [ARCHETYPE-548](https://issues.apache.org/jira/browse/ARCHETYPE-548) and [ARCHETYPE-499](https://issues.apache.org/jira/browse/ARCHETYPE-499) it is described how archetypes generated with `mvn archetype:create-from-project` do not include resource files without file extensions. We ran into the same issue with Dockerfile, as did others.

This PR generates a `<include>` (e.g. `**/Dockerfile`) for files without extension. In addition the `<include>**/*.</include>`, which was added in case of an empty extension has been removed for this case.

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. 
  Note that commits might be squashed by a maintainer on merge.
- [~] Write unit tests  that match behavioral changes, where the tests fail if the changes to the runtime are not applied. 
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).


If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [ ] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
