### PR TITLE
fix: replace deprecated StringUtils.contains calls in ArchetypeSelectorUtils

### DIFF
--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/ArchetypeSelectorUtils.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/ui/generation/ArchetypeSelectorUtils.java
@@ -37,12 +37,12 @@ public class ArchetypeSelectorUtils {
     }
 
     private static String extractGroupIdFromFilter(String filter) {
-        return StringUtils.contains(filter, ':') ? StringUtils.substringBefore(filter, ":") : null;
+        return filter.contains(":") ? StringUtils.substringBefore(filter, ":") : null;
     }
 
     private static String extractArtifactIdFromFilter(String filter) {
         // if no : the full text is considered as artifactId content
-        return StringUtils.contains(filter, ':') ? StringUtils.substringAfter(filter, ":") : filter;
+        return filter.contains(":") ? StringUtils.substringAfter(filter, ":") : filter;
     }
 
     /**
@@ -66,8 +66,8 @@ public class ArchetypeSelectorUtils {
                 String groupId = ArchetypeSelectorUtils.extractGroupIdFromFilter(filter);
                 String artifactId = ArchetypeSelectorUtils.extractArtifactIdFromFilter(filter);
 
-                if (((groupId == null) || StringUtils.contains(archetype.getGroupId(), groupId))
-                        && StringUtils.contains(archetype.getArtifactId(), artifactId)) {
+                if (((groupId == null) || archetype.getGroupId().contains(groupId))
+                        && archetype.getArtifactId().contains(artifactId)) {
                     archetypes.add(archetype);
                 }
             }


### PR DESCRIPTION
Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. 
  Note that commits might be squashed by a maintainer on merge.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. 
  This may not always be possible but is a best-practice.
- [x] Run `mvn verify` to make sure basic checks pass.
  A more thorough check will be performed on your pull request automatically.
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).


If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
- [x] In any other case, please file an [Apache Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

Fixes : #951

This PR updates ArchetypeSelectorUtils to use `String.contains(...)` instead of deprecated `StringUtils.contains` methods. This removes warnings, reduces dependency usage, and simplifies the filter-parsing logic. No functional changes.
