### PR TITLE
issue:983 fix create-from-project / preserveCData / multi-modules

### DIFF
--- a/archetype-common/src/main/java/org/apache/maven/archetype/creator/FilesetArchetypeCreator.java
+++ b/archetype-common/src/main/java/org/apache/maven/archetype/creator/FilesetArchetypeCreator.java
@@ -487,8 +487,8 @@ public class FilesetArchetypeCreator implements ArchetypeCreator {
             throws IOException, XmlPullParserException {
         Model pom = pomManager.readPom(FileUtils.resolveFile(basedir, Constants.ARCHETYPE_POM));
 
-        String parentArtifactId = pomReversedProperties.getProperty(Constants.PARENT_ARTIFACT_ID);
-        String artifactId = pom.getArtifactId();
+        String previousParentArtifactId = pomReversedProperties.getProperty(Constants.PARENT_ARTIFACT_ID);
+        String previousArtifactId = pomReversedProperties.getProperty(Constants.ARTIFACT_ID);
         setParentArtifactId(pomReversedProperties, pomReversedProperties.getProperty(Constants.ARTIFACT_ID));
         setArtifactId(pomReversedProperties, pom.getArtifactId());
 
@@ -518,8 +518,8 @@ public class FilesetArchetypeCreator implements ArchetypeCreator {
                 preserveCData,
                 keepParent);
 
-        restoreParentArtifactId(pomReversedProperties, parentArtifactId);
-        restoreArtifactId(pomReversedProperties, artifactId);
+        restoreParentArtifactId(pomReversedProperties, previousParentArtifactId);
+        restoreArtifactId(pomReversedProperties, previousArtifactId);
     }
 
     @SuppressWarnings("checkstyle:ParameterNumber")

--- a/maven-archetype-plugin/src/it/projects/issue-983-preserve-cdata/archetype.properties
+++ b/maven-archetype-plugin/src/it/projects/issue-983-preserve-cdata/archetype.properties
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+archetype.groupId=org.codehaus.mojo.archetypes
+archetype.artifactId=maven-archetype-test
+archetype.version=1.0
+groupId=org.apache.maven.archetype.test
+artifactId=test-issue-983-preserve-cdata
+version=1.0-SNAPSHOT
+package=org.apache.maven.archetype
+someProperty=A String to search for
+excludePatterns=build.log,invoker.properties,verify.groovy

--- a/maven-archetype-plugin/src/it/projects/issue-983-preserve-cdata/invoker.properties
+++ b/maven-archetype-plugin/src/it/projects/issue-983-preserve-cdata/invoker.properties
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+invoker.goals = org.apache.maven.plugins:maven-archetype-plugin:${project.version}:create-from-project -Darchetype.preserveCData
+

--- a/maven-archetype-plugin/src/it/projects/issue-983-preserve-cdata/pom.xml
+++ b/maven-archetype-plugin/src/it/projects/issue-983-preserve-cdata/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project
+    xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.apache.maven.archetype.test</groupId>
+    <artifactId>test-issue-983-preserve-cdata</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <name>Maven archetype Test issue-983-preserve-cdata</name>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>subModule1</module>
+        <module>subModule2</module>
+    </modules>
+</project>

--- a/maven-archetype-plugin/src/it/projects/issue-983-preserve-cdata/subModule1/pom.xml
+++ b/maven-archetype-plugin/src/it/projects/issue-983-preserve-cdata/subModule1/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.archetype.test</groupId>
+    <artifactId>test-issue-983-preserve-cdata</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>test-issue-983-preserve-cdata-subModule1</artifactId>
+  <name>Maven archetype Test issue-983-preserve-cdata-subModule1</name>
+  <packaging>pom</packaging>
+
+</project>

--- a/maven-archetype-plugin/src/it/projects/issue-983-preserve-cdata/subModule2/pom.xml
+++ b/maven-archetype-plugin/src/it/projects/issue-983-preserve-cdata/subModule2/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache.maven.archetype.test</groupId>
+    <artifactId>test-issue-983-preserve-cdata</artifactId>
+    <version>1.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>test-issue-983-preserve-cdata-subModule2</artifactId>
+  <name>Maven archetype Test issue-983-preserve-cdata-subModule2</name>
+  <packaging>pom</packaging>
+  
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.maven.archetype.test</groupId>
+      <artifactId>test-issue-983-preserve-cdata-subModule1</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/maven-archetype-plugin/src/it/projects/issue-983-preserve-cdata/verify.groovy
+++ b/maven-archetype-plugin/src/it/projects/issue-983-preserve-cdata/verify.groovy
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+def template = new File(basedir, 'target/generated-sources/archetype/src/main/resources/archetype-resources/subModule2/pom.xml')
+// dependency subModule1 must be kept
+assert template.text.contains('${parentArtifactId}-subModule1')
+ 


### PR DESCRIPTION
Related to #983

When a multi-module project is used with create-from-project with preserveCData, dependencies between modules are broken.

For the following hierarchy :
* A
  * B
  * C -> B

The built archetype replace B dependency in C module with a A dependency.

This commit adds an integration test triggering the issue and a fix.

Fix restore correctly the ${parentArtifactId} value:
* before: previous module artifactId is used (so B module setup ${parentArtifactId} B value)
* after: original value when entering the method is restored (so B module setup ${parentArticatId} A value)

Following this checklist to help us incorporate your
contribution quickly and easily:

- [x] Your pull request should address just one issue, without pulling in other changes.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. -> **I only write an integration test**
- [x] Run `mvn verify` to make sure basic checks pass. -> **mvn -Prun-its verify**
- [x] You have run the integration tests successfully (`mvn -Prun-its verify`).


[x] If your pull request is about ~20 lines of code you don't need to sign an
[Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf) if you are unsure
please ask on the developers list.

To make clear that you license your contribution under
the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
you have to acknowledge this by using the following check-box.

- [x] I hereby declare this contribution to be licenced under the [Apache License Version 2.0, January 2004](http://www.apache.org/licenses/LICENSE-2.0)
