### PR TITLE
Provide project remote repositories in IT runs

### DIFF
--- a/maven-archetype-plugin/pom.xml
+++ b/maven-archetype-plugin/pom.xml
@@ -258,6 +258,9 @@
                       <source>src/it/mrm/repository</source>
                       <cloneTo>target/mock-repo</cloneTo>
                     </mockRepo>
+                    <localRepo>
+                      <source>${project.build.directory}/local-repo</source>
+                    </localRepo>
                     <proxyRepo />
                   </repositories>
                 </configuration>

--- a/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/IntegrationTestMojo.java
+++ b/maven-archetype-plugin/src/main/java/org/apache/maven/archetype/mojos/IntegrationTestMojo.java
@@ -502,6 +502,7 @@ public class IntegrationTestMojo extends AbstractMojo {
                 .setPackage(properties.getProperty(Constants.PACKAGE))
                 .setMavenSession(session)
                 .setRepositorySession(session.getRepositorySession())
+                .setRemoteRepositories(project.getRemoteProjectRepositories())
                 .setOutputDirectory(basedir)
                 .setProperties(properties);
         // @formatter:on


### PR DESCRIPTION
Integration tests resolve archetype artifact twice...

First, it is done with the list of remote repositories, and second, without remote repositories.

Resolver 2.x is more restrictive and does not allow using an artifact from the local repository with a different remote repository.

Fix for Maven 3.10.x
