### PR TITLE
Restore the document metadata dropped when the pages were ported

### DIFF
--- a/archetype-common/src/site/markdown/internal.md
+++ b/archetype-common/src/site/markdown/internal.md
@@ -1,3 +1,10 @@
+---
+title: Maven Archetype Internal Catalog
+author: 
+  - Hervé Boutemy
+date: 2010-04-06
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/archetype-models/archetype-catalog/src/site/markdown/index.md
+++ b/archetype-models/archetype-catalog/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Maven Archetype Catalog Model
+author: 
+  - Hervé Boutemy
+date: 2011-08-21
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/archetype-models/archetype-descriptor/src/site/markdown/index.md
+++ b/archetype-models/archetype-descriptor/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: Maven Archetype Descriptor Model
+author: 
+  - Hervé Boutemy
+date: 2011-08-21
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/archetype-packaging/src/site/markdown/archetype-packaging.md.vm
+++ b/archetype-packaging/src/site/markdown/archetype-packaging.md.vm
@@ -1,3 +1,10 @@
+---
+title: Maven Archetype Packaging Reference
+author: 
+  - Hervé Boutemy
+date: 2018-02-24
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/archetype-packaging/src/site/markdown/index.md.vm
+++ b/archetype-packaging/src/site/markdown/index.md.vm
@@ -1,3 +1,10 @@
+---
+title: About
+author: 
+  - Hervé Boutemy
+date: 2011-08-28
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-archetype-plugin/src/site/markdown/advanced-usage.md
+++ b/maven-archetype-plugin/src/site/markdown/advanced-usage.md
@@ -1,3 +1,10 @@
+---
+title: Advanced Usage
+author: 
+  - Raphaël Piéroni
+date: 2008
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-archetype-plugin/src/site/markdown/archetype-repository.md
+++ b/maven-archetype-plugin/src/site/markdown/archetype-repository.md
@@ -1,3 +1,10 @@
+---
+title: Archetype Repository
+author: 
+  - Robert Scholte
+date: 2017-04-01
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-archetype-plugin/src/site/markdown/examples/create-multi-module-project.md
+++ b/maven-archetype-plugin/src/site/markdown/examples/create-multi-module-project.md
@@ -1,3 +1,10 @@
+---
+title: Create an archetype from a multi-module project
+author: 
+  - Raphaël Piéroni
+date: 2011-09-30
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-archetype-plugin/src/site/markdown/examples/create-with-property-file.md
+++ b/maven-archetype-plugin/src/site/markdown/examples/create-with-property-file.md
@@ -1,3 +1,10 @@
+---
+title: Create an archetype with a property file
+author: 
+  - Raphaël Piéroni
+date: 2011-09-30
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-archetype-plugin/src/site/markdown/examples/generate-alternative-catalog.md
+++ b/maven-archetype-plugin/src/site/markdown/examples/generate-alternative-catalog.md
@@ -1,3 +1,10 @@
+---
+title: Generate project using an alternative catalog
+author: 
+  - Raphaël Piéroni
+date: 2010-09-11
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-archetype-plugin/src/site/markdown/examples/generate-batch.md
+++ b/maven-archetype-plugin/src/site/markdown/examples/generate-batch.md
@@ -1,3 +1,10 @@
+---
+title: Generate project in batch mode
+author: 
+  - Raphaël Piéroni
+date: 2011-09-30
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-archetype-plugin/src/site/markdown/index.md.vm
+++ b/maven-archetype-plugin/src/site/markdown/index.md.vm
@@ -1,3 +1,11 @@
+---
+title: Introduction
+author: 
+  - Raphaël Piéroni
+  - Hervé Boutemy
+date: 2011-09-30
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-archetype-plugin/src/site/markdown/specification/archetype-catalog.md
+++ b/maven-archetype-plugin/src/site/markdown/specification/archetype-catalog.md
@@ -1,3 +1,10 @@
+---
+title: Archetype Catalog
+author: 
+  - Raphaël Piéroni
+date: 2011-09-30
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-archetype-plugin/src/site/markdown/specification/archetype-metadata.md
+++ b/maven-archetype-plugin/src/site/markdown/specification/archetype-metadata.md
@@ -1,3 +1,10 @@
+---
+title: Archetype Metadata
+author: 
+  - Raphaël Piéroni
+date: 2011-09-30
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-archetype-plugin/src/site/markdown/specification/archetype.md
+++ b/maven-archetype-plugin/src/site/markdown/specification/archetype.md
@@ -1,3 +1,10 @@
+---
+title: Archetype
+author: 
+  - Raphaël Piéroni
+date: 2011-09-30
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-archetype-plugin/src/site/markdown/specification/crawl-repository.md
+++ b/maven-archetype-plugin/src/site/markdown/specification/crawl-repository.md
@@ -1,3 +1,10 @@
+---
+title: Crawl Repository
+author: 
+  - Raphaël Piéroni
+date: 10 February 2008
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-archetype-plugin/src/site/markdown/specification/create-from-project.md
+++ b/maven-archetype-plugin/src/site/markdown/specification/create-from-project.md
@@ -1,3 +1,10 @@
+---
+title: Create an Archetype from a Project
+author: 
+  - Raphaël Piéroni
+date: 2011-09-30
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-archetype-plugin/src/site/markdown/specification/generate.md
+++ b/maven-archetype-plugin/src/site/markdown/specification/generate.md
@@ -1,3 +1,10 @@
+---
+title: Create a Project from an Archetype
+author: 
+  - Raphaël Piéroni
+date: 2011-09-30
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-archetype-plugin/src/site/markdown/specification/specification.md
+++ b/maven-archetype-plugin/src/site/markdown/specification/specification.md
@@ -1,3 +1,10 @@
+---
+title: Specification
+author: 
+  - Raphaël Piéroni
+date: 2011-09-30
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-archetype-plugin/src/site/markdown/specification/update-catalog.md
+++ b/maven-archetype-plugin/src/site/markdown/specification/update-catalog.md
@@ -1,3 +1,10 @@
+---
+title: Update local and remote Catalog
+author: 
+  - Raphaël Piéroni
+date: 10 February 2008
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/maven-archetype-plugin/src/site/markdown/usage.md
+++ b/maven-archetype-plugin/src/site/markdown/usage.md
@@ -1,3 +1,12 @@
+---
+title: Usage
+author: 
+  - Raphaël Piéroni
+  - Olivier Lamy
+  - Hervé Boutemy
+date: 2011-09-30
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -1,3 +1,10 @@
+---
+title: About
+author: 
+  - Jason van Zyl
+date: 2009-08-26
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
The site pages lost their document metadata when they were ported from APT.

An APT document opens with a header block giving its title, authors and date, and
`doxia-converter` turns that into YAML front matter. The port dropped the front matter
along with the converter's per-line licence comments, so the generated pages lost their
`<meta name="author">` and date, and took their `<title>` from the first heading instead
of from the document title.

Building one project's site from the APT sources and from the ported Markdown shows the
difference:

| | `<title>` produced |
|---|---|
| APT original | `Release Notes - Modello` |
| ported Markdown | `Modello - Modello` |
| with this change | `Release Notes - Modello` |

The front matter has to come first in the file, because the Markdown parser only looks
for it when the source begins with `---`; a licence header ahead of it would hide it.
RAT is happy either way.

Verified by building the site before and after and comparing `<title>` and the author
meta tags of every generated page, and by confirming the front matter does not reach
the rendered body.