### PR TITLE
Drop backslash escapes that Markdown does not need

### DIFF
--- a/maven-archetype-plugin/src/site/markdown/examples/create-multi-module-project.md
+++ b/maven-archetype-plugin/src/site/markdown/examples/create-multi-module-project.md
@@ -224,7 +224,7 @@ package: com.company
 [INFO] ------------------------------------------------------------------------
 ```
 
-As one can see, Velocity, the internal processor of archetype files, complains about not finding some properties. One should not worry about that. What is more interesting, is that the archetype plugin has renamed the original project module to "\_\_rootArtifactId\_\_". And during the generation that name is converted to the provided artifactId.
+As one can see, Velocity, the internal processor of archetype files, complains about not finding some properties. One should not worry about that. What is more interesting, is that the archetype plugin has renamed the original project module to "\__rootArtifactId\_\_". And during the generation that name is converted to the provided artifactId.
 
 The resulting directory tree of the project is shown here.
 


### PR DESCRIPTION
Pages converted from APT with an older `doxia-converter` carry a backslash in front of
punctuation that is not markup where it stands, for example `maven\-source\-plugin`,
`\(default\)` and `required\.`. The backslash renders as nothing; it only makes the source
harder to read and to edit, which was the point of moving to Markdown.

Only positions where the bare character can never be markup are touched: a hyphen,
underscore or asterisk between two word characters, a parenthesis, a full stop that
does not follow a digit, and an exclamation mark not followed by `[`.

Left alone deliberately:

* angle brackets, since `<escapeString>` really would be read as an HTML tag
* a full stop after a digit, so an ordered list marker cannot appear by accident
* a run of dots, because bare `...` is rendered as a single ellipsis character
* code spans, fenced blocks and link destinations

Verified by building the site before and after: every generated page is identical in
its visible text and in every link target.